### PR TITLE
Use the maximum precision from time.time() in discrimiating log files

### DIFF
--- a/mmcif/io/IoAdapterBase.py
+++ b/mmcif/io/IoAdapterBase.py
@@ -179,7 +179,7 @@ class IoAdapterBase(object):
 
     def __getDiscriminator(self):
         """Internal method returning a string which can discriminate among default file names -"""
-        return str(int(time.time() * 10000))
+        return str(time.time() * 10000).replace(".", "_")
 
     def _chooseTemporaryPath(self, filePath, outDirPath=None):
         """Select a path for temporary files in the priority order


### PR DESCRIPTION
When creating the name of the log file in parsing files, int(time.time() * 10000) is used as part of the name.  

time.time() is designed to provide unique values between calls - but the three digits past the decimal point (after *10000) are being dropped.

One would think this would provide sufficient precision to prevent collision. However, in multithreaded web servers, this is not sufficient an occasionally collisions occur.

This patch uses the maximum precision of time.time() - after multiplying by 10000, replace decimal point with underscore. This ensures that it does not appear as a file suffix.
[log.txt](https://github.com/rcsb/py-mmcif/files/6455631/log.txt)
