### PR TITLE
Simple change to handle attributes that aren't found in DictionaryAPI __definitionIndex

### DIFF
--- a/mmcif/api/DataCategoryTyped.py
+++ b/mmcif/api/DataCategoryTyped.py
@@ -223,7 +223,7 @@ class DataCategoryTyped(DataCategory):
         cifDataType = self.__dApi.getTypeCode(self.getName(), atName)
         cifPrimitiveType = self.__dApi.getTypePrimitive(self.getName(), atName)
         isMandatory = self.__dApi.getMandatoryCode(self.getName(), atName) in ["yes", "implicit", "implicit-ordinal"]
-        dataType = "integer" if "int" in cifDataType else "float" if cifPrimitiveType == "numb" else "string"
+        dataType = "string" if cifDataType is None else "integer" if "int" in cifDataType else "float" if cifPrimitiveType == "numb" else "string"
         return dataType, isMandatory
 
     def __isClose(self, aV, bV, relTol=1e-09, absTol=1e-06):

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -128,7 +128,7 @@ class BinaryCifWriter(object):
         """
         cifDataType = self.__dApi.getTypeCode(dObj.getName(), atName)
         cifPrimitiveType = self.__dApi.getTypePrimitive(dObj.getName(), atName)
-        dataType = "integer" if "int" in cifDataType else "float" if cifPrimitiveType == "numb" else "string"
+        dataType = "string" if cifDataType is None else "integer" if "int" in cifDataType else "float" if cifPrimitiveType == "numb" else "string"
         return dataType
 
 


### PR DESCRIPTION
Using the dictionary found at 
https://github.com/ihmwg/ModelCIF/tree/master/dist
conversion of PDB entries to BCIF occasionally fails due to various attributes not being found in the DictionaryApi's __defintionIndex. Currently, this means that DictionaryApi.getTypeCode() returns None, which causes issues in DataCategoryTyped.__getAttributeInfo() on initialization and BinaryCifWriter.__getAttributeType() when attempting to serialize. 

A selection of attributes that were found to cause issues:

'diffrn', 'struct_conn', 'em_3d_fitting', 'diffrn_detector', 'pdbx_branch_scheme', 'pdbx_entity_branch', 'em_3d_reconstruction', 'pdbx_contact_author', 'pdbx_serial_crystallography_sample_delivery', 'reflns', 'branch_link' 

An example of an entry that fails to convert because of this is 6JZI from PDB, which fails due to 'diffrn' not being found in the DictionarApi's __definitionIndex.

The code that calls the serialization:

`
import os
from tempfile import NamedTemporaryFile

from mmcif.io.BinaryCifWriter import BinaryCifWriter
from mmcif.io.IoAdapterPy import IoAdapterPy as IoAdapter
from mmcif.api.DataCategoryTyped import DataCategoryTyped
from mmcif.api.PdbxContainers import DataContainer
from mmcif.api.DictionaryApi import DictionaryApi

def get_serialized_bcif_from_cif(filepath_cif):

    HERE = os.path.abspath(os.path.dirname(__file__))
    myIo = IoAdapter(raiseExceptions=True)
    
    __containerList = myIo.readFile(
        inputFilePath=os.path.join(HERE, "mmcif_combined.dic")
    ) # downloaded from https://github.com/ihmwg/ModelCIF/blob/master/dist/mmcif_ma.dic
    __dApi = DictionaryApi(containerList = __containerList, consolidate=True)

    tcL = []
    ioPy = IoAdapter()
    containerList = ioPy.readFile(filepath_cif, cleanUp=True)
    for container in containerList:
        cName = container.getName()
        tc = DataContainer(cName)
        for catName in container.getObjNameList():
            if catName in tough_categories:
                continue
            dObj = container.getObj(catName)
            tObj = DataCategoryTyped(dObj, dictionaryApi=__dApi, ignoreCastErrors=True)
            tc.append(tObj)
        tcL.append(tc)
    bcw = BinaryCifWriter(
        dictionaryApi=__dApi,
        storeStringsAsBytes=True, applyTypes=False, useFloat64=False,
    )
    with NamedTemporaryFile("rb") as ntf:
        bcw.serialize(ntf.name, tcL)
        serialized_version = ntf.read()
    return serialized_version
`

