### PR TITLE
Mkdocs fix

### DIFF
--- a/docs-mkdocs/api_reference/BinaryCifReader.md
+++ b/docs-mkdocs/api_reference/BinaryCifReader.md
@@ -1,3 +1,3 @@
-::: mmcif.io.BinaryCifReader:BinaryCifReader
+::: mmcif.io.BinaryCifReader.BinaryCifReader
 
-::: mmcif.io.BinaryCifReader:BinaryCifDecoders
+::: mmcif.io.BinaryCifReader.BinaryCifDecoders

--- a/docs-mkdocs/api_reference/BinaryCifWriter.md
+++ b/docs-mkdocs/api_reference/BinaryCifWriter.md
@@ -1,3 +1,3 @@
-::: mmcif.io.BinaryCifWriter:BinaryCifWriter
+::: mmcif.io.BinaryCifWriter.BinaryCifWriter
 
-::: mmcif.io.BinaryCifWriter:BinaryCifEncoders
+::: mmcif.io.BinaryCifWriter.BinaryCifEncoders

--- a/docs-mkdocs/api_reference/CifFile.md
+++ b/docs-mkdocs/api_reference/CifFile.md
@@ -1,1 +1,1 @@
-::: mmcif.io.CifFile:CifFile
+::: mmcif.io.CifFile.CifFile

--- a/docs-mkdocs/api_reference/DataCategory.md
+++ b/docs-mkdocs/api_reference/DataCategory.md
@@ -1,1 +1,1 @@
-::: mmcif.api.DataCategory:DataCategory
+::: mmcif.api.DataCategory.DataCategory

--- a/docs-mkdocs/api_reference/DataCategoryBase.md
+++ b/docs-mkdocs/api_reference/DataCategoryBase.md
@@ -1,1 +1,1 @@
-::: mmcif.api.DataCategoryBase:DataCategoryBase
+::: mmcif.api.DataCategoryBase.DataCategoryBase

--- a/docs-mkdocs/api_reference/DataCategoryFormatted.md
+++ b/docs-mkdocs/api_reference/DataCategoryFormatted.md
@@ -1,1 +1,1 @@
-::: mmcif.api.DataCategoryFormatted:DataCategoryFormatted
+::: mmcif.api.DataCategoryFormatted.DataCategoryFormatted

--- a/docs-mkdocs/api_reference/DataCategoryTyped.md
+++ b/docs-mkdocs/api_reference/DataCategoryTyped.md
@@ -1,1 +1,1 @@
-::: mmcif.api.DataCategoryTyped:DataCategoryTyped
+::: mmcif.api.DataCategoryTyped.DataCategoryTyped

--- a/docs-mkdocs/api_reference/DictMethodRunner.md
+++ b/docs-mkdocs/api_reference/DictMethodRunner.md
@@ -1,1 +1,1 @@
-::: mmcif.api.DictMethodRunner:DictMethodRunner
+::: mmcif.api.DictMethodRunner.DictMethodRunner

--- a/docs-mkdocs/api_reference/DictionaryApi.md
+++ b/docs-mkdocs/api_reference/DictionaryApi.md
@@ -1,1 +1,1 @@
-::: mmcif.api.DictionaryApi:DictionaryApi
+::: mmcif.api.DictionaryApi.DictionaryApi

--- a/docs-mkdocs/api_reference/DictionaryInclude.md
+++ b/docs-mkdocs/api_reference/DictionaryInclude.md
@@ -1,1 +1,1 @@
-::: mmcif.api.DictionaryInclude:DictionaryInclude
+::: mmcif.api.DictionaryInclude.DictionaryInclude

--- a/docs-mkdocs/api_reference/IoAdapterBase.md
+++ b/docs-mkdocs/api_reference/IoAdapterBase.md
@@ -1,1 +1,1 @@
-::: mmcif.io.IoAdapterBase:IoAdapterBase
+::: mmcif.io.IoAdapterBase.IoAdapterBase

--- a/docs-mkdocs/api_reference/IoAdapterCore.md
+++ b/docs-mkdocs/api_reference/IoAdapterCore.md
@@ -1,1 +1,1 @@
-::: mmcif.io.IoAdapterCore:IoAdapterCore
+::: mmcif.io.IoAdapterCore.IoAdapterCore

--- a/docs-mkdocs/api_reference/IoAdapterPy.md
+++ b/docs-mkdocs/api_reference/IoAdapterPy.md
@@ -1,1 +1,1 @@
-::: mmcif.io.IoAdapterPy:IoAdapterPy
+::: mmcif.io.IoAdapterPy.IoAdapterPy

--- a/docs-mkdocs/api_reference/Method.md
+++ b/docs-mkdocs/api_reference/Method.md
@@ -1,3 +1,3 @@
-::: mmcif.api.Method:MethodDefinition
+::: mmcif.api.Method.MethodDefinition
 
-::: mmcif.api.Method:MethodReference
+::: mmcif.api.Method.MethodReference

--- a/docs-mkdocs/api_reference/MethodUtils.md
+++ b/docs-mkdocs/api_reference/MethodUtils.md
@@ -1,1 +1,1 @@
-::: mmcif.api.MethodUtils:MethodUtils
+::: mmcif.api.MethodUtils.MethodUtils

--- a/docs-mkdocs/api_reference/PdbxContainers.md
+++ b/docs-mkdocs/api_reference/PdbxContainers.md
@@ -1,9 +1,9 @@
-::: mmcif.api.PdbxContainers:ContainerBase
+::: mmcif.api.PdbxContainers.ContainerBase
 
-::: mmcif.api.PdbxContainers:DefinitionContainer
+::: mmcif.api.PdbxContainers.DefinitionContainer
 
-::: mmcif.api.PdbxContainers:DataContainer
+::: mmcif.api.PdbxContainers.DataContainer
 
-::: mmcif.api.PdbxContainers:SaveFrameContainer
+::: mmcif.api.PdbxContainers.SaveFrameContainer
 
-::: mmcif.api.PdbxContainers:CifName
+::: mmcif.api.PdbxContainers.CifName

--- a/docs-mkdocs/api_reference/PdbxExceptions.md
+++ b/docs-mkdocs/api_reference/PdbxExceptions.md
@@ -1,3 +1,3 @@
-::: mmcif.io.PdbxExceptions:PdbxError
+::: mmcif.io.PdbxExceptions.PdbxError
 
-::: mmcif.io.PdbxExceptions:PdbxSyntaxError
+::: mmcif.io.PdbxExceptions.PdbxSyntaxError

--- a/docs-mkdocs/api_reference/PdbxReader.md
+++ b/docs-mkdocs/api_reference/PdbxReader.md
@@ -1,1 +1,1 @@
-::: mmcif.io.PdbxReader:PdbxReader
+::: mmcif.io.PdbxReader.PdbxReader

--- a/docs-mkdocs/api_reference/PdbxWriter.md
+++ b/docs-mkdocs/api_reference/PdbxWriter.md
@@ -1,1 +1,1 @@
-::: mmcif.io.PdbxWriter:PdbxWriter
+::: mmcif.io.PdbxWriter.PdbxWriter

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,7 +48,6 @@ plugins:
               - "!^_[^_]"
               - "!^__json"
               - "!^__config__"
-            new_path_syntax: true
       watch:
         - mmcif
 

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,5 +1,5 @@
 mkdocs
-mkdocstrings
+mkdocstrings[python-legacy]>=0.18
 mkdocs-material
 markdown-include
 pymdown-extensions


### PR DESCRIPTION
With newer version of mkdocstrings, indicate python handler. 

We use the legacy one for now as the experimental one has issues with generators.  Will need to re-evaluate in  future.

There are also a series of changes for include paths. The legacy python handler : is allowed, but the newer one, "." will be required.