### PR TITLE
V0.84 - Updates to error suppression flags for undefined attribute types in BCIF conversion

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -79,3 +79,4 @@
 08-Apr-2023    V0.81 - When using C++ writer, a string with a tab in middle with no other whitespace must be quoted
  5-Dec-2023    V0.82 - Add support for binary mmCIF (BCIF) reading and writing in IoAdapterPy
  8-Dec-2023    V0.83 - Updates to error suppression flags for undefined attribute types in BCIF conversion (set default to on)
+21-Dec-2023    V0.84 - Update wheel builds for Apple Silicon (arm64).

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -78,3 +78,4 @@
 04-Dec-2022    V0.80.1 - Correct non-wheel build of legacy python
 08-Apr-2023    V0.81 - When using C++ writer, a string with a tab in middle with no other whitespace must be quoted
  5-Dec-2023    V0.82 - Add support for binary mmCIF (BCIF) reading and writing in IoAdapterPy
+ 8-Dec-2023    V0.83 - Updates to error suppression flags for undefined attribute types in BCIF conversion (set default to on)

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -79,4 +79,4 @@
 08-Apr-2023    V0.81 - When using C++ writer, a string with a tab in middle with no other whitespace must be quoted
  5-Dec-2023    V0.82 - Add support for binary mmCIF (BCIF) reading and writing in IoAdapterPy
 21-Dec-2023    V0.83 - Update wheel builds for Apple Silicon (arm64).
-21-Dec-2023    V0.84 - Updates to error suppression flags for undefined attribute types in BCIF conversion (set default to on)
+ 2-Jan-2024    V0.84 - Updates to error suppression flags for undefined attribute types in BCIF conversion (set default to on)

--- a/mmcif/__init__.py
+++ b/mmcif/__init__.py
@@ -2,6 +2,6 @@ __docformat__ = "google en"
 __author__ = "John Westbrook"
 __email__ = "john.westbrook@rcsb.org"
 __license__ = "Apache 2.0"
-__version__ = "0.83"
+__version__ = "0.84"
 
 __apiUrl__ = "https://mmcif.wwpdb.org"

--- a/mmcif/__init__.py
+++ b/mmcif/__init__.py
@@ -2,6 +2,6 @@ __docformat__ = "google en"
 __author__ = "John Westbrook"
 __email__ = "john.westbrook@rcsb.org"
 __license__ = "Apache 2.0"
-__version__ = "0.82"
+__version__ = "0.83"
 
 __apiUrl__ = "https://mmcif.wwpdb.org"

--- a/mmcif/api/DataCategoryTyped.py
+++ b/mmcif/api/DataCategoryTyped.py
@@ -89,6 +89,10 @@ class DataCategoryTyped(DataCategory):
             for ii, atName in enumerate(self.getAttributeList()):
                 # colValL = self.getColumn(ii)
                 dataType, isMandatory = self.__getAttributeInfo(atName)
+                if not dataType:
+                    if not ignoreCastErrors:
+                        logger.error("Undefined type for category %s attribute %s - Will treat as string", self.getName(), atName)
+                    dataType = "string"  # Treat undefined attributes as strings
                 missingValue = missingValueInteger if dataType == "integer" else missingValueFloat if dataType in ["integer", "float"] else missingValueString
                 missingValue = missingValue if not useCifUnknowns else "." if isMandatory else "?"
                 for row in self.data:
@@ -224,7 +228,10 @@ class DataCategoryTyped(DataCategory):
         cifDataType = self.__dApi.getTypeCode(self.getName(), atName)
         cifPrimitiveType = self.__dApi.getTypePrimitive(self.getName(), atName)
         isMandatory = self.__dApi.getMandatoryCode(self.getName(), atName) in ["yes", "implicit", "implicit-ordinal"]
-        dataType = "string" if cifDataType is None else "integer" if "int" in cifDataType else "float" if cifPrimitiveType == "numb" else "string"
+        if cifDataType is None:
+            dataType = None
+        else:
+            dataType = "integer" if "int" in cifDataType else "float" if cifPrimitiveType == "numb" else "string"
         return dataType, isMandatory
 
     def __isClose(self, aV, bV, relTol=1e-09, absTol=1e-06):

--- a/mmcif/io/IoAdapterPy.py
+++ b/mmcif/io/IoAdapterPy.py
@@ -232,6 +232,7 @@ class IoAdapterPy(IoAdapterBase):
         useStringTypes=False,
         useFloat64=False,
         copyInputData=False,
+        ignoreCastErrors=False,
         **kwargs
     ):
         """Write input list of data containers to the specified output file path in mmCIF or BCIF format.
@@ -256,6 +257,7 @@ class IoAdapterPy(IoAdapterBase):
             useStringTypes (bool, optional): assume all types are string (for BCIF files only). Defaults to False.
             useFloat64 (bool, optional): store floats with 64 bit precision (for BCIF files only). Defaults to False.
             copyInputData (bool, optional): make a new copy input data (for BCIF files only). Defaults to False.
+            ignoreCastErrors (bool, optional): suppress errors when casting attribute types with dictionaryApi. Defaults to False.
 
             **kwargs: Placeholder for unsupported key value pairs
 
@@ -298,6 +300,7 @@ class IoAdapterPy(IoAdapterBase):
                         useStringTypes=useStringTypes,
                         useFloat64=useFloat64,
                         copyInputData=copyInputData,
+                        ignoreCastErrors=ignoreCastErrors,
                     )
                     bcifW.serialize(outputFilePath, containerList)
                 else:


### PR DESCRIPTION
A consequence of merging https://github.com/rcsb/py-mmcif/pull/13 recently is that if undefined attributes are encountered, they are automatically treated as strings; however, no warning message is logged about doing so, making the user unaware that the assumption was made. It also makes the user unaware that a given attribute was not defined in the input dictionary.

This PR extends the use of the `ignoreCastErrors` flag to log an error message when such a case arises (default behavior). If a user wants to suppress these errors, they can set the flag to `True`.