### PR TITLE
MacOS ARM support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,13 @@ class CMakeBuild(build_ext):
             cmakeArgs += ["-DCMAKE_BUILD_TYPE=" + cfg]
             buildArgs += ["--", "-j2"]
 
+
+        if sys.platform.startswith("darwin"):
+            # Cross-compile support for macOS - respect ARCHFLAGS if set
+            archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
+            if archs:
+                cmake_args += ["-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))]
+
         env = os.environ.copy()
         env["CXXFLAGS"] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get("CXXFLAGS", ""), self.distribution.get_version())
         env["RUN_FROM_DISUTILS"] = "yes"

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ class CMakeBuild(build_ext):
             # Cross-compile support for macOS - respect ARCHFLAGS if set
             archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
             if archs:
-                cmake_args += ["-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))]
+                cmakeArgs += ["-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))]
 
         env = os.environ.copy()
         env["CXXFLAGS"] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get("CXXFLAGS", ""), self.distribution.get_version())


### PR DESCRIPTION
cibuildwheel cross compiles for MacOS ARM64 platform

This changes passes flags to cmake to build the cross-platform version.