### PR TITLE
V0.85.0 - Update BinaryCIF read and write tools, update package version format to major.minor.patch

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -80,3 +80,7 @@
  5-Dec-2023    V0.82 - Add support for binary mmCIF (BCIF) reading and writing in IoAdapterPy
 21-Dec-2023    V0.83 - Update wheel builds for Apple Silicon (arm64).
  2-Jan-2024    V0.84 - Updates to error suppression flags for undefined attribute types in BCIF conversion (set default to on)
+16-Jan-2024    V0.85.0 - Update BinaryCifReader to read in DataCategory data items into lists instead of tuples;
+                         Update BinaryCifWriter to set version tag to that of the active mmcif package installation,
+                         to enable compatibility with Mol* and other tools (which requires >= 0.3.0, in that format);
+                         Update package version format to `major.minor.patch` (!!! MUST USE THIS FORMAT MOVING FORWARD !!!)

--- a/mmcif/__init__.py
+++ b/mmcif/__init__.py
@@ -2,6 +2,6 @@ __docformat__ = "google en"
 __author__ = "John Westbrook"
 __email__ = "john.westbrook@rcsb.org"
 __license__ = "Apache 2.0"
-__version__ = "0.84"
+__version__ = "0.85.0"
 
 __apiUrl__ = "https://mmcif.wwpdb.org"

--- a/mmcif/io/BinaryCifReader.py
+++ b/mmcif/io/BinaryCifReader.py
@@ -110,7 +110,8 @@ class BinaryCifReader(object):
                     #
                     cObj = DataCategory(catName, attributeNameList=atNameList)
                     genL = [colGen for colGen in colD.values()]
-                    for row in zip(*genL):
+                    for rowTup in zip(*genL):
+                        row = list(rowTup)
                         logger.debug("row %r", row)
                         cObj.append(row)
                     #

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -12,6 +12,7 @@ import logging
 import struct
 import msgpack
 
+from mmcif import __version__
 from mmcif.api.DataCategoryTyped import DataCategoryTyped
 from mmcif.io.BinaryCifReader import BinaryCifDecoders
 
@@ -44,7 +45,7 @@ class BinaryCifWriter(object):
             copyInputData (bool, optional): make a new copy input data. Defaults to False.
             ignoreCastErrors (bool, optional): suppress errors when casting attribute types with dictionaryApi. Defaults to False.
         """
-        self.__version = "0.01"
+        self.__version = str(__version__) if __version__ and len(str(__version__).split(".")) == 3 else "0.85.0"
         self.__storeStringsAsBytes = storeStringsAsBytes
         self.__defaultStringEncoding = defaultStringEncoding
         self.__applyTypes = applyTypes

--- a/mmcif/tests/testPdbxWriter.py
+++ b/mmcif/tests/testPdbxWriter.py
@@ -14,7 +14,6 @@ __docformat__ = "google en"
 __author__ = "John Westbrook"
 __email__ = "jwest@rcsb.rutgers.edu"
 __license__ = "Apache 2.0"
-__version__ = "V0.01"
 
 
 import logging


### PR DESCRIPTION
- Update `BinaryCifReader` to read in DataCategory data items into lists instead of tuples;
- Update `BinaryCifWriter` to set version tag to that of the active mmcif package installation, to enable compatibility with Mol* and other tools (which requires >= `0.3.0`, in that format);
- Update package version format to `major.minor.patch` (must use this format moving forward!)