### PR TITLE
V0.85.1 - Set BinaryCIF version tag to specifically 0.3.0

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -84,3 +84,4 @@
                          Update BinaryCifWriter to set version tag to that of the active mmcif package installation,
                          to enable compatibility with Mol* and other tools (which requires >= 0.3.0, in that format);
                          Update package version format to `major.minor.patch` (!!! MUST USE THIS FORMAT MOVING FORWARD !!!)
+17-Jan-2024    V0.85.1 - Set BinaryCIF version tag to specifically 0.3.0 to ensure compatibility with Mol* and other tools

--- a/mmcif/__init__.py
+++ b/mmcif/__init__.py
@@ -2,6 +2,6 @@ __docformat__ = "google en"
 __author__ = "John Westbrook"
 __email__ = "john.westbrook@rcsb.org"
 __license__ = "Apache 2.0"
-__version__ = "0.85.0"
+__version__ = "0.85.1"
 
 __apiUrl__ = "https://mmcif.wwpdb.org"

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -12,7 +12,6 @@ import logging
 import struct
 import msgpack
 
-from mmcif import __version__
 from mmcif.api.DataCategoryTyped import DataCategoryTyped
 from mmcif.io.BinaryCifReader import BinaryCifDecoders
 
@@ -45,7 +44,7 @@ class BinaryCifWriter(object):
             copyInputData (bool, optional): make a new copy input data. Defaults to False.
             ignoreCastErrors (bool, optional): suppress errors when casting attribute types with dictionaryApi. Defaults to False.
         """
-        self.__version = str(__version__) if __version__ and len(str(__version__).split(".")) == 3 else "0.85.0"
+        self.__version = "0.3.0"
         self.__storeStringsAsBytes = storeStringsAsBytes
         self.__defaultStringEncoding = defaultStringEncoding
         self.__applyTypes = applyTypes


### PR DESCRIPTION
Set BinaryCIF version tag to specifically 0.3.0 to ensure compatibility with Mol* and other tools.

Mol* requires version `0.3.0` or greater:
- Version declaration: https://github.com/molstar/molstar/blob/22e5c9d65b2714bc6e59713361d8a39200ee0508/src/mol-io/common/binary-cif/encoding.ts#L10 
- Version checker: https://github.com/molstar/molstar/blob/22e5c9d65b2714bc6e59713361d8a39200ee0508/src/mol-io/reader/cif/binary/parser.ts#L14-L19

The Java codec expects version `0.3.*` and would reject `0.4.*`, `0.85.*`, etc.:
- Version pattern declaration: https://github.com/rcsb/ciftools-java/blob/6548dc01ec803b0d41022f5c92990b695d7b9403/src/main/java/org/rcsb/cif/binary/codec/BinaryCifCodec.java#L26
- Version checker: https://github.com/rcsb/ciftools-java/blob/6548dc01ec803b0d41022f5c92990b695d7b9403/src/main/java/org/rcsb/cif/binary/BinaryCifReader.java#L37


