### PR TITLE
Quote strings that start global_

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -85,3 +85,4 @@
                          to enable compatibility with Mol* and other tools (which requires >= 0.3.0, in that format);
                          Update package version format to `major.minor.patch` (!!! MUST USE THIS FORMAT MOVING FORWARD !!!)
 17-Jan-2024    V0.85.1 - Set BinaryCIF version tag to specifically 0.3.0 to ensure compatibility with Mol* and other tools
+ 6-Apr-2024    V0.86.0 - Correct internal data of PdbxContainers when rename operation is used

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -78,3 +78,4 @@
 04-Dec-2022    V0.80.1 - Correct non-wheel build of legacy python
 08-Apr-2023    V0.81 - When using C++ writer, a string with a tab in middle with no other whitespace must be quoted
  5-Dec-2023    V0.82 - Add support for binary mmCIF (BCIF) reading and writing in IoAdapterPy
+21-Dec-2023    V0.83 - Update wheel builds for Apple Silicon (arm64).

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -84,3 +84,4 @@
                          Update BinaryCifWriter to set version tag to that of the active mmcif package installation,
                          to enable compatibility with Mol* and other tools (which requires >= 0.3.0, in that format);
                          Update package version format to `major.minor.patch` (!!! MUST USE THIS FORMAT MOVING FORWARD !!!)
+17-Jan-2024    V0.85.1 - Set BinaryCIF version tag to specifically 0.3.0 to ensure compatibility with Mol* and other tools

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -88,3 +88,4 @@
 23-Feb-2024    V0.86.0 - BinaryCIF writer properly tracks integer types to ensure
                          proper types passed through encoders.  Ensure compatibility with ciftools-java and Mol*.
  6-Apr-2024    V0.87.0 - Correct internal data of PdbxContainers when rename operation is used
+20-Jun-2024    V0.87.0 - When writing output cif, always quote strings that start global_

--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -4,7 +4,7 @@
 skip = ["pp*", "*-musllinux*"]
 
 [tool.cibuildwheel.linux]
-before-all = "yum -y install flex bison cmake"
+before-all = "sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo ; sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo; yum -y install flex bison cmake"
 test-command = 'python -c "from mmcif.io.IoAdapterCore import IoAdapterCore as IoAdapter"'
 
 [[tool.cibuildwheel.overrides]]

--- a/mmcif/__init__.py
+++ b/mmcif/__init__.py
@@ -2,6 +2,6 @@ __docformat__ = "google en"
 __author__ = "John Westbrook"
 __email__ = "john.westbrook@rcsb.org"
 __license__ = "Apache 2.0"
-__version__ = "0.85.1"
+__version__ = "0.86.0"
 
 __apiUrl__ = "https://mmcif.wwpdb.org"

--- a/mmcif/__init__.py
+++ b/mmcif/__init__.py
@@ -2,6 +2,6 @@ __docformat__ = "google en"
 __author__ = "John Westbrook"
 __email__ = "john.westbrook@rcsb.org"
 __license__ = "Apache 2.0"
-__version__ = "0.86.0"
+__version__ = "0.87.0"
 
 __apiUrl__ = "https://mmcif.wwpdb.org"

--- a/mmcif/__init__.py
+++ b/mmcif/__init__.py
@@ -2,6 +2,6 @@ __docformat__ = "google en"
 __author__ = "John Westbrook"
 __email__ = "john.westbrook@rcsb.org"
 __license__ = "Apache 2.0"
-__version__ = "0.82"
+__version__ = "0.83"
 
 __apiUrl__ = "https://mmcif.wwpdb.org"

--- a/mmcif/__init__.py
+++ b/mmcif/__init__.py
@@ -2,6 +2,6 @@ __docformat__ = "google en"
 __author__ = "John Westbrook"
 __email__ = "john.westbrook@rcsb.org"
 __license__ = "Apache 2.0"
-__version__ = "0.85.0"
+__version__ = "0.85.1"
 
 __apiUrl__ = "https://mmcif.wwpdb.org"

--- a/mmcif/__init__.py
+++ b/mmcif/__init__.py
@@ -2,6 +2,6 @@ __docformat__ = "google en"
 __author__ = "John Westbrook"
 __email__ = "john.westbrook@rcsb.org"
 __license__ = "Apache 2.0"
-__version__ = "0.87.0"
+__version__ = "0.88.0"
 
 __apiUrl__ = "https://mmcif.wwpdb.org"

--- a/mmcif/api/DataCategoryFormatted.py
+++ b/mmcif/api/DataCategoryFormatted.py
@@ -133,7 +133,7 @@ class DataCategoryFormatted(DataCategory):
                     return (self.__doubleQuotedList(inp), "DT_ITEM_NAME")
                 elif inp[0] in ["[", "]", "$", "#", ";"]:
                     return (self.__doubleQuotedList(inp), "DT_DOUBLE_QUOTED_STRING")
-                elif inp[:5].lower() in ["data_", "loop_", "save_", "stop_"]:
+                elif inp[:5].lower() in ["data_", "loop_", "save_", "stop_"] or inp[:7].lower() in ["global_"]:
                     return (self.__doubleQuotedList(inp), "DT_DOUBLE_QUOTED_STRING")
                 else:
                     return ([str(inp)], "DT_UNQUOTED_STRING")

--- a/mmcif/api/PdbxContainers.py
+++ b/mmcif/api/PdbxContainers.py
@@ -203,6 +203,7 @@ class ContainerBase(object):
             self.__objNameList[i] = newName
             self.__objCatalog[newName] = self.__objCatalog[curName]
             self.__objCatalog[newName].setName(newName)
+            del self.__objCatalog[curName]
             return True
         except Exception:
             return False

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -12,7 +12,6 @@ import logging
 import struct
 import msgpack
 
-from mmcif import __version__
 from mmcif.api.DataCategoryTyped import DataCategoryTyped
 from mmcif.io.BinaryCifReader import BinaryCifDecoders
 
@@ -45,7 +44,7 @@ class BinaryCifWriter(object):
             copyInputData (bool, optional): make a new copy input data. Defaults to False.
             ignoreCastErrors (bool, optional): suppress errors when casting attribute types with dictionaryApi. Defaults to False.
         """
-        self.__version = str(__version__) if __version__ and len(str(__version__).split(".")) == 3 else "0.85.0"
+        self.__version = "0.3.0"
         self.__storeStringsAsBytes = storeStringsAsBytes
         self.__defaultStringEncoding = defaultStringEncoding
         self.__applyTypes = applyTypes

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -235,6 +235,7 @@ class BinaryCifEncoders(object):
             colDataList = TypedArray(colDataList)
             legacy = True
 
+        encDict = None
         for encType in encodingTypeList:
             if encType == "ByteArray":
                 colDataList, encDict = self.byteArrayEncoderTyped(colDataList, dataType)
@@ -650,6 +651,7 @@ class BinaryCifEncoders(object):
 
             encodedColDataList.append(colVal)
 
+        byteArrayType = None  # Should never happen, but keep pylint happy. 4 bytes handled above
         if nbytes == 1:
             byteArrayType = "integer_8" if isSigned else "unsigned_integer_8"
         elif nbytes == 2:

--- a/mmcif/tests/testCifQuoting.py
+++ b/mmcif/tests/testCifQuoting.py
@@ -136,6 +136,14 @@ class QuotingTests(unittest.TestCase):
         aCat.append([9, "Stop_in_the_name_of_love"])
         curContainer.append(aCat)
 
+        # This category is for testing of quoting of global.  Python parser will lose registration and not parse
+        aCat = DataCategory("pdbx_test_global")
+        aCat.appendAttribute("a")
+        aCat.appendAttribute("b")
+        aCat.appendAttribute("c")
+        aCat.append(["Global_should_be_ok", "test", "value"])
+        curContainer.append(aCat)
+
         return curContainer
 
     def __testValues(self, containerList):
@@ -145,6 +153,9 @@ class QuotingTests(unittest.TestCase):
         catObj = c0.getObj("pdbx_test")
         self.assertIsNotNone(catObj)
         self.assertEqual(catObj.getValue("details", 7), "DatA_my_big_data_file")
+        catObj = c0.getObj("pdbx_test_global")
+        self.assertIsNotNone(catObj)
+        self.assertEqual(catObj.getValue("a", 0), "Global_should_be_ok")
 
 
 def suiteFileCase():

--- a/mmcif/tests/testPdbxContainers.py
+++ b/mmcif/tests/testPdbxContainers.py
@@ -1,0 +1,136 @@
+##
+# File:    testPdbxContainer.py
+# Author:  ep
+# Date:    6-Apri-2023
+# Version: 0.001
+#
+# Update:
+##
+"""
+Test container PdbxContainers functionality
+"""
+__docformat__ = "google en"
+__author__ = "Ezra Peisach"
+__email__ = "peisach@rcsb.rutgers.edu"
+__license__ = "Apache 2.0"
+
+
+import logging
+import os
+import os.path
+import sys
+import time
+import unittest
+
+from mmcif.api.DataCategory import DataCategory
+from mmcif.api.PdbxContainers import DataContainer
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+TOPDIR = os.path.dirname(os.path.dirname(HERE))
+
+try:
+    from mmcif import __version__
+except ImportError:
+    sys.path.insert(0, TOPDIR)
+    from mmcif import __version__
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s]-%(module)s.%(funcName)s: %(message)s")
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+class PdbxContainersTests(unittest.TestCase):
+    def setUp(self):
+        self.lfh = sys.stderr
+        self.verbose = False
+        #
+        self.__startTime = time.time()
+        logger.debug("Running tests on version %s", __version__)
+        logger.debug("Starting %s at %s", self.id(), time.strftime("%Y %m %d %H:%M:%S", time.localtime()))
+
+    def tearDown(self):
+        endTime = time.time()
+        logger.debug("Completed %s at %s (%.4f seconds)", self.id(), time.strftime("%Y %m %d %H:%M:%S", time.localtime()), endTime - self.__startTime)
+
+    def __createContainer(self):
+        """Creates a containter with data"""
+
+        curContainer = DataContainer("myblock")
+
+        # Create category
+        aCat = DataCategory("pdbx_seqtool_mapping_ref")
+        aCat.appendAttribute("ordinal")
+        aCat.appendAttribute("entity_id")
+        aCat.appendAttribute("auth_mon_id")
+        aCat.appendAttribute("auth_mon_num")
+        aCat.appendAttribute("pdb_chain_id")
+        aCat.appendAttribute("ref_mon_id")
+        aCat.appendAttribute("ref_mon_num")
+        aCat.append((1, 2, 3, 4, "55555555555555555555555555555555555555555555", 6, 7))
+        aCat.append((1, 2, 3, 4, "5555", 6, 7))
+
+        curContainer.append(aCat)
+
+        return curContainer
+
+    def testGeneral(self):
+        """Tests some simple aspects
+        """
+
+        blk = self.__createContainer()
+
+        self.assertEqual(blk.getName(), "myblock")
+        blk.setName("New")
+        self.assertEqual(blk.getName(), "New")
+
+    def testRename(self):
+        """Tests if renaming category results in old name still available in
+        getObj()
+        """
+
+        blk = self.__createContainer()
+
+        curName = "pdbx_seqtool_mapping_ref"
+        newName = "newName"
+
+        # Current - access to curName ok, newName gives nothing
+        self.assertEqual(blk.getObjNameList(), [curName])
+        self.assertTrue(blk.exists(curName))
+        self.assertFalse(blk.exists(newName))
+        self.assertIsNotNone(blk.getObj(curName))
+        self.assertIsNone(blk.getObj(newName))
+
+        # Now rename
+        # Test non existant
+        self.assertFalse(blk.rename("noname", "othernoname"))
+
+        # Expect nothing changed
+        self.assertEqual(blk.getObjNameList(), [curName])
+        self.assertTrue(blk.exists(curName))
+        self.assertFalse(blk.exists(newName))
+        self.assertIsNotNone(blk.getObj(curName))
+        self.assertIsNone(blk.getObj(newName))
+
+        # Rename proper
+        self.assertTrue(blk.rename(curName, newName))
+
+        # Expect nothing changed
+        self.assertEqual(blk.getObjNameList(), [newName])
+        self.assertFalse(blk.exists(curName))
+        self.assertTrue(blk.exists(newName))
+        self.assertIsNone(blk.getObj(curName))
+        self.assertIsNotNone(blk.getObj(newName))
+
+
+def containerSuite():
+    suiteSelect = unittest.TestSuite()
+    suiteSelect.addTest(PdbxContainersTests("testGeneral"))
+    suiteSelect.addTest(PdbxContainersTests("testRename"))
+    return suiteSelect
+
+
+if __name__ == "__main__":
+    mySuite = containerSuite()
+    unittest.TextTestRunner(verbosity=2).run(mySuite)
+#

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,13 @@ class CMakeBuild(build_ext):
             cmakeArgs += ["-DCMAKE_BUILD_TYPE=" + cfg]
             buildArgs += ["--", "-j2"]
 
+
+        if sys.platform.startswith("darwin"):
+            # Cross-compile support for macOS - respect ARCHFLAGS if set
+            archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
+            if archs:
+                cmakeArgs += ["-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))]
+
         env = os.environ.copy()
         env["CXXFLAGS"] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get("CXXFLAGS", ""), self.distribution.get_version())
         env["RUN_FROM_DISUTILS"] = "yes"


### PR DESCRIPTION
When writing CIF output, strings that start with global_ (case insensitive) must be quoted - even without whitespace.