### PR TITLE
Use explicit item type map to determine field types and encodings

### DIFF
--- a/azure-template-tox-job.yml
+++ b/azure-template-tox-job.yml
@@ -154,7 +154,7 @@ jobs:
       #  Build artifacts if this is a test target (i.e. labeled as py##)
       #
       - ? ${{ if and( startsWith(parameters.tox, 'py'), not(startsWith(parameters.python, '2.7')) ) }}
-        : - script: pip install --upgrade pip twine setuptools wheel cibuildwheel==2.19.2
+        : - script: pip install --upgrade pip twine setuptools wheel cibuildwheel==2.20.0
             displayName: "Install build tools"
           - script: python setup.py  sdist --dist-dir "$(System.DefaultWorkingDirectory)/dist"
             displayName: "Build source distribution"

--- a/mmcif/__init__.py
+++ b/mmcif/__init__.py
@@ -2,6 +2,6 @@ __docformat__ = "google en"
 __author__ = "John Westbrook"
 __email__ = "john.westbrook@rcsb.org"
 __license__ = "Apache 2.0"
-__version__ = "0.89.0"
+__version__ = "0.90.0"
 
 __apiUrl__ = "https://mmcif.wwpdb.org"

--- a/mmcif/api/DataCategoryTyped.py
+++ b/mmcif/api/DataCategoryTyped.py
@@ -107,16 +107,16 @@ class DataCategoryHints:
     def __init__(self, **kwargs):
         pass
 
-    def inMolStarIntHints(self, field):
-        """Returns True if field is in Mol* enforced-integer list; False otherwise
+    def inMolStarIntHints(self, name):
+        """Returns True if field name is in Mol* enforced-integer list; False otherwise
 
         Args:
-            field: field name
+            name: field name
 
         Returns:
-            (bool): True if field is in Mol* enforced-integer list; False otherwise
+            (bool): True if field name is in Mol* enforced-integer list; False otherwise
         """
-        return field in self.__molstar_forced_ints
+        return name in self.__molstar_forced_ints
 
     def getPdbxItemType(self, typeCode):
         """Returns the item type corresponding to a given _item_type.code from PDBx dictionary

--- a/mmcif/api/DataCategoryTyped.py
+++ b/mmcif/api/DataCategoryTyped.py
@@ -29,31 +29,105 @@ logger = logging.getLogger(__name__)
 
 class DataCategoryHints:
     """A class which will support hints for data types"""
-    __molstar_forced_ints = [
-        '_atom_site.id',
-        '_atom_site.auth_seq_id',
-        '_atom_site_anisotrop.id',
-        '_pdbx_struct_mod_residue.auth_seq_id',
-        '_struct_conf.beg_auth_seq_id',
-        '_struct_conf.end_auth_seq_id',
-        '_struct_conn.ptnr1_auth_seq_id',
-        '_struct_conn.ptnr2_auth_seq_id',
-        '_struct_sheet_range.beg_auth_seq_id',
-        '_struct_sheet_range.end_auth_seq_id',
-    ]
+    #
+    __molstar_forced_ints = {
+        "_atom_site.id": "integer",
+        "_atom_site.auth_seq_id": "integer",
+        "_atom_site_anisotrop.id": "integer",
+        "_pdbx_struct_mod_residue.auth_seq_id": "integer",
+        "_struct_conf.beg_auth_seq_id": "integer",
+        "_struct_conf.end_auth_seq_id": "integer",
+        "_struct_conn.ptnr1_auth_seq_id": "integer",
+        "_struct_conn.ptnr2_auth_seq_id": "integer",
+        "_struct_sheet_range.beg_auth_seq_id": "integer",
+        "_struct_sheet_range.end_auth_seq_id": "integer",
+    }
+    #
+    __pdbx_item_type_list_map = {
+        # Strings
+        "code": "string",  # char
+        "line": "string",  # char
+        "text": "string",  # char
+        "boolean": "string",  # char
+        "ucode": "string",  # uchar
+        "uline": "string",  # uchar
+        "name": "string",  # uchar
+        "idname": "string",  # uchar
+        "any": "string",  # char
+        "yyyy-mm-dd": "string",  # char
+        "yyyy-mm-dd:hh:mm-flex": "string",  # char
+        "uchar3": "string",  # uchar
+        "uchar5": "string",  # uchar
+        "uchar1": "string",  # uchar
+        "symop": "string",  # char
+        "atcode": "string",  # char
+        "yyyy-mm-dd:hh:mm": "string",  # char
+        "fax": "string",  # uchar
+        "phone": "string",  # uchar
+        "email": "string",  # uchar
+        "code30": "string",  # char
+        "binary": "string",  # char
+        "operation_expression": "string",  # char
+        "ec-type": "string",  # char
+        "seq-one-letter-code": "string",  # char
+        "ucode-alphanum-csv": "string",  # uchar
+        "point_symmetry": "string",  # char
+        "asym_id": "string",  # char
+        "id_list": "string",  # char
+        "id_list_spc": "string",  # char
+        "3x4_matrices": "string",  # char
+        "3x4_matrix": "string",  # char
+        "pdbx_related_db_id": "string",  # char
+        "pdbx_PDB_obsoleted_db_id": "string",  # char
+        "emd_id": "string",  # char
+        "pdb_id": "string",  # char
+        "pdb_id_u": "string",  # uchar
+        "point_group": "string",  # char
+        "point_group_helical": "string",  # char
+        "author": "string",  # char
+        "orcid_id": "string",  # char
+        "symmetry_operation": "string",  # char
+        "sequence_dep": "string",  # char
+        "date_dep": "string",  # char
+        "citation_doi": "string",  # char
+        "exp_data_doi": "string",  # char
+        "deposition_email": "string",  # uchar
+        "entity_id_list": "string",  # uchar
+        "int_list": "string",  # uchar
+        "uniprot_ptm_id": "string",  # char
+        "int-range": "string",  # numb
+        "float-range": "string",  # numb
+        # Integers
+        "int": "integer",  # numb,
+        "positive_int": "integer",  # numb,
+        # Floats
+        "float": "float",  # numb,
+    }
 
     def __init__(self, **kwargs):
         pass
 
-    def getMolStarIntHints(self):
-        """Returns list of attributes that mol* would prefer as an integer
+    def inMolStarIntHints(self, field):
+        """Returns True if field is in Mol* enforced-integer list; False otherwise
 
         Args:
+            field: field name
 
         Returns:
-            (list): list of attributes
+            (bool): True if field is in Mol* enforced-integer list; False otherwise
         """
-        return self.__molstar_forced_ints
+        return field in self.__molstar_forced_ints
+
+    def getPdbxItemType(self, typeCode):
+        """Returns the item type corresponding to a given _item_type.code from PDBx dictionary
+
+        Args:
+            typeCode: field type code
+
+        Returns:
+            (str): item type corresponding to given type codes; else, if not present, "string"
+        """
+        return self.__pdbx_item_type_list_map.get(typeCode, "string")
 
 
 class DataCategoryTyped(DataCategory):
@@ -99,6 +173,7 @@ class DataCategoryTyped(DataCategory):
         self.__attributeTypeD = {}
         self.__castD = {"integer": int, "float": float, "string": str}
         self.__applyMolStarTypes = kwargs.get("applyMolStarTypes", True)
+        self.__dch = DataCategoryHints()
 
         self.__typesSet = self.applyTypes(
             ignoreCastErrors=ignoreCastErrors,
@@ -260,18 +335,18 @@ class DataCategoryTyped(DataCategory):
         """
         logger.debug("Working on cat %r, atName %r", self.getName(), atName)
         cifDataType = self.__dApi.getTypeCode(self.getName(), atName)
-        cifPrimitiveType = self.__dApi.getTypePrimitive(self.getName(), atName)
+        # cifPrimitiveType = self.__dApi.getTypePrimitive(self.getName(), atName)
         isMandatory = self.__dApi.getMandatoryCode(self.getName(), atName) in ["yes", "implicit", "implicit-ordinal"]
         if cifDataType is None:
             dataType = None
         else:
-            dataType = "integer" if "int" in cifDataType else "float" if cifPrimitiveType == "numb" else "string"
+            dataType = self.__dch.getPdbxItemType(cifDataType)
+            # dataType = "integer" if "int" in cifDataType else "float" if cifPrimitiveType == "numb" else "string"
 
         # Allow for forced Mol* integer types
         if self.__applyMolStarTypes:
-            dch = DataCategoryHints()
             nm = CifName().itemName(self.getName(), atName)
-            if nm in dch.getMolStarIntHints():
+            if self.__dch.inMolStarIntHints(nm):
                 dataType = "integer"
 
         return dataType, isMandatory

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -57,10 +57,7 @@ class BinaryCifWriter(object):
         self.__copyInputData = copyInputData
         self.__ignoreCastErrors = ignoreCastErrors
         self.__applyMolStarTypes = kwargs.get("applyMolStarTypes", True)
-        if self.__applyTypes and self.__applyMolStarTypes:
-            self.__dch = DataCategoryHints()
-        else:
-            self.__dch = None
+        self.__dch = DataCategoryHints()
 
     def serialize(self, filePath, containerList):
         """Serialize the input container list in binary CIF and store these data in the input file path.
@@ -150,18 +147,19 @@ class BinaryCifWriter(object):
             (string): data type (string, integer or float)
         """
         cifDataType = self.__dApi.getTypeCode(dObj.getName(), atName)
-        cifPrimitiveType = self.__dApi.getTypePrimitive(dObj.getName(), atName)
+        # cifPrimitiveType = self.__dApi.getTypePrimitive(dObj.getName(), atName)
         if cifDataType is None:
             dataType = "string"
             if not self.__ignoreCastErrors:
                 logger.warning("Undefined type for category %s attribute %s - Will treat as string", dObj.getName(), atName)
         else:
-            dataType = "integer" if "int" in cifDataType else "float" if cifPrimitiveType == "numb" else "string"
+            dataType = self.__dch.getPdbxItemType(cifDataType)
+            # dataType = "integer" if "int" in cifDataType else "float" if cifPrimitiveType == "numb" else "string"
 
         # Only if applying types, do we allow Mol* hints
         if self.__applyTypes and self.__applyMolStarTypes:
             nm = CifName().itemName(dObj.getName(), atName)
-            if nm in self.__dch.getMolStarIntHints():
+            if self.__dch.inMolStarIntHints(nm):
                 dataType = "integer"
 
         return dataType


### PR DESCRIPTION
This PR is intended to address a current limitation in the conversion of mmCIF to BCIF for some data items. 

Specifically, there's a bug when handling some uncommon data types such as `point_group` and `float_range`.
- `point_group` fails because it has "**int**" in the name (i.e., "po**int**_group")
- `float_range` fails because it has "**float**" in the name, so the code tries to encode it as a float, but really it's a string since the value contains a hyphen

Rather than having the code try to figure out what the type is and how to encode it based on substring matching, I've added a [current] complete list of possible types and what they should be encoded as. This is similar to the method being used by our Java encoder (e.g., see [here](https://github.com/rcsb/ciftools-java/blob/06e095fc0a97a3dba7e90b1345e7c90743f3d45b/src/main/java/org/rcsb/cif/schema/generator/SchemaGenerator.java#L522)). 

Additionally, I made a minor adjustment to the `__molstar_forced_ints` object, in which I changed it to be a dictionary rather than a list to allow for O(1) efficiency.