### PR TITLE
Cleanup mkdocs.yml to include source path

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,7 +38,8 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          rendering:
+          paths: [mmcif]
+          options:
             group_by_category: true
             show_category_heading: true
             show_if_no_docstring: true
@@ -48,8 +49,6 @@ plugins:
               - "!^_[^_]"
               - "!^__json"
               - "!^__config__"
-      watch:
-        - mmcif
 
 theme:
   name: material


### PR DESCRIPTION
Cleanup problematic MkDocs.yml for legacy MkDocstrings usage that has shift.