### PR TITLE
Corrections for BinaryCIF encoding of masks, and masked integer arrays

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -97,7 +97,11 @@
  7-May-2025    V0.92.0 - BinaryCIF ByteArray Encoder failed to use the provided
                          array type in recorded output type.  Warn deprecation of
 			 obsolete encoders
-16-Oct-2025    V1.0.0 - Remove support for python 2.X, retain support for
-                        python 3.6 and newer.  Switch to using pyproject.toml for
-			metadata. Build wheels for python 3.8->3.14
+16-Oct-2025    V1.0.0  - Remove support for python 2.X, retain support for
+                         python 3.6 and newer.  Switch to using pyproject.toml for
+                         metadata. Build wheels for python 3.8->3.14
 
+24-Nov-2026    V1.1.0  - BinaryCIF encoder corrections: Masked interer encodings
+                         should default to 0 in array.  Masks should be encoded as
+                         as uint_8.  RunLength encoding should specify the incoming
+                         data type.

--- a/mmcif/__init__.py
+++ b/mmcif/__init__.py
@@ -2,6 +2,6 @@ __docformat__ = "google en"
 __author__ = "John Westbrook"
 __email__ = "john.westbrook@rcsb.org"
 __license__ = "Apache 2.0"
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 __apiUrl__ = "https://mmcif.wwpdb.org"

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -113,14 +113,16 @@ class BinaryCifWriter(object):
         colMaskDict = None  # Use None when no mask and not {} - per Mol* implementation
         enc = BinaryCifEncoders(defaultStringEncoding=self.__defaultStringEncoding, storeStringsAsBytes=self.__storeStringsAsBytes, useFloat64=self.__useFloat64)
         #
-        maskEncoderList = ["Delta", "RunLength", "IntegerPacking", "ByteArray"]
+        maskEncoderList = ["RunLength", "ByteArray"]
         typeEncoderD = {"string": "StringArrayMasked", "integer": "IntArrayMasked", "float": "FloatArrayMasked"}
         colMaskList = enc.getMask(colDataList)
         dataEncType = typeEncoderD[dataType]
         colDataEncoded, colDataEncodingDictL = enc.encodeWithMask(colDataList, colMaskList, dataEncType)
         if colMaskList:
-            maskEncoded, maskEncodingDictL = enc.encode(colMaskList, maskEncoderList, "integer")
-            colMaskDict = {self.__toBytes("data"): maskEncoded, self.__toBytes("encoding"): maskEncodingDictL}
+            # Mol* indicates that masks should be encoded as if uint_8
+            colMaskListTyped = TypedArray(colMaskList, "unsigned_integer_8")
+            maskEncoded, maskEncodingDictL = enc.encode(colMaskListTyped, maskEncoderList, "integer")
+            colMaskDict = {self.__toBytes("data"): maskEncoded.data, self.__toBytes("encoding"): maskEncodingDictL}
         return colMaskDict, colDataEncoded, colDataEncodingDictL
 
     def __toBytes(self, strVal):
@@ -409,8 +411,13 @@ class BinaryCifEncoders(object):
         if len(colTypedDataList.data) <= minLen:
             return colTypedDataList, None
 
+        if colTypedDataList.dtype:
+            srcType = colTypedDataList.dtype
+        else:
+            srcType = "integer_32"
+
         byteArrayType = "integer_32"
-        encodingD = {self.__toBytes("kind"): self.__toBytes("RunLength"), self.__toBytes("srcType"): self.__bCifTypeCodeD[byteArrayType],
+        encodingD = {self.__toBytes("kind"): self.__toBytes("RunLength"), self.__toBytes("srcType"): self.__bCifTypeCodeD[srcType],
                      self.__toBytes("srcSize"): len(colTypedDataList.data)}
         encodedColDataList = []
         val = None
@@ -486,7 +493,9 @@ class BinaryCifEncoders(object):
         integerEncoderList = ["Delta", "RunLength", "IntegerPacking", "ByteArray"]
 
         if colMaskList:
-            maskedColDataList = [-1 if m else d for m, d in zip(colMaskList, colDataList)]
+            # Mol* and BinaryCif specification https://github.com/molstar/BinaryCIF/blob/master/encoding.md
+            # indcates that masked (missing) data are encoded as 0
+            maskedColDataList = [0 if m else d for m, d in zip(colMaskList, colDataList)]
         else:
             maskedColDataList = colDataList
         encodedColDataList, encodingDictL = self.encode(maskedColDataList, integerEncoderList, "integer")

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -411,12 +411,8 @@ class BinaryCifEncoders(object):
         if len(colTypedDataList.data) <= minLen:
             return colTypedDataList, None
 
-        if colTypedDataList.dtype:
-            srcType = colTypedDataList.dtype
-        else:
-            srcType = "integer_32"
+        srcType = self.__getDataType(colTypedDataList)
 
-        byteArrayType = "integer_32"
         encodingD = {self.__toBytes("kind"): self.__toBytes("RunLength"), self.__toBytes("srcType"): self.__bCifTypeCodeD[srcType],
                      self.__toBytes("srcSize"): len(colTypedDataList.data)}
         encodedColDataList = []
@@ -435,7 +431,7 @@ class BinaryCifEncoders(object):
         if len(encodedColDataList) > len(colTypedDataList.data):
             return colTypedDataList, None
         else:
-            encodedTypedColDataList = TypedArray(encodedColDataList, byteArrayType)
+            encodedTypedColDataList = TypedArray(encodedColDataList, "integer_32")
             return encodedTypedColDataList, encodingD
 
     def stringArrayMaskedEncoder(self, colDataList, colMaskList):


### PR DESCRIPTION
The critical issue is that masked integer arrays should encode 0 in the array instead of -1.  This has recently been clarified in https://github.com/molstar/BinaryCIF/blob/master/encoding.md#masks .  The upshot is that RCSB PDB produced bcif files had -1 as the charge on most atoms.   

Other changes discovered:  Mol* implementation encodes masks as uint_8.  This reduces the encoding options to RunLength and ByteArray due to incoming and outgoing formats.  This matches Mol*.

RunLength encoding was setting the incoming type as int32 -- regardless of the incoming type.  As RunLength accepts only integer arrays - this likely worked - but is proper.  Discovered relative to Mol* packing.
