### PR TITLE
V1.1.1  - Remove python 2 references

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,11 +26,7 @@ message(STATUS "Python include path set to " ${PYTHON_INCLUDE_DIRS})
 #  -- Build a wrapper library  --
 #
 message(STATUS "Python version is " ${PYTHON_VERSION_STRING})
-if(${PYTHON_VERSION_STRING} VERSION_LESS "3.8")
-  add_subdirectory("modules/pybind11_2_12_1")
-else()
-  add_subdirectory("modules/pybind11")  
-endif()
+add_subdirectory("modules/pybind11")  
 #
 #
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -100,8 +100,8 @@
 16-Oct-2025    V1.0.0  - Remove support for python 2.X, retain support for
                          python 3.6 and newer.  Switch to using pyproject.toml for
                          metadata. Build wheels for python 3.8->3.14
-
 24-Nov-2026    V1.1.0  - BinaryCIF encoder corrections: Masked interer encodings
                          should default to 0 in array.  Masks should be encoded as
                          as uint_8.  RunLength encoding should specify the incoming
                          data type.
+19-Mar-2026    V1.1.1  - Remove python 2 references

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -101,7 +101,9 @@
                          python 3.6 and newer.  Switch to using pyproject.toml for
                          metadata. Build wheels for python 3.8->3.14
 
-24-Nov-2026    V1.1.0  - BinaryCIF encoder corrections: Masked interer encodings
+24-Nov-2025    V1.1.0  - BinaryCIF encoder corrections: Masked interer encodings
                          should default to 0 in array.  Masks should be encoded as
                          as uint_8.  RunLength encoding should specify the incoming
                          data type.
+23-Apr-2026    V1.1.1  - Remove support for python 3.6 as setuptools needed for
+                         pyproject.toml does not function

--- a/mmcif/__init__.py
+++ b/mmcif/__init__.py
@@ -2,6 +2,6 @@ __docformat__ = "google en"
 __author__ = "John Westbrook"
 __email__ = "john.westbrook@rcsb.org"
 __license__ = "Apache 2.0"
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 __apiUrl__ = "https://mmcif.wwpdb.org"

--- a/mmcif/io/IoAdapterBase.py
+++ b/mmcif/io/IoAdapterBase.py
@@ -9,6 +9,7 @@
 #    6-Aug-2018 jdw add _setContainerProperties() to assign default container properties
 #   10-Aug-2018 jdw add _uncompress() method (suppress xz as lzma is not support in py27)
 #   11-Nov-2018 jdw add method to _chooseTemporaryPath()
+#   19-Mar-2026 dwp remove python 2.7 references
 ##
 """
 Base class presenting essential PDBx/mmCIF IO methods.
@@ -101,10 +102,7 @@ class IoAdapterBase(object):
             return False
 
     def _getTimeStamp(self):
-        if sys.version_info[0] > 2:
-            utcnow = datetime.datetime.now(datetime.timezone.utc)
-        else:
-            utcnow = datetime.datetime.utcnow()
+        utcnow = datetime.datetime.now(datetime.timezone.utc)
         ts = utcnow.strftime("%Y-%m-%d:%H:%M:%S")
         return ts
 

--- a/mmcif/io/IoAdapterBase.py
+++ b/mmcif/io/IoAdapterBase.py
@@ -21,7 +21,6 @@ __author__ = "John Westbrook"
 __email__ = "john.westbrook@rcsb.org"
 __license__ = "Apache 2.0"
 
-import sys
 import bz2
 import datetime
 import gzip

--- a/mmcif/io/IoAdapterPy.py
+++ b/mmcif/io/IoAdapterPy.py
@@ -15,6 +15,7 @@
 #  5-Apr-2021 jdw allow access to data/dictionary artifacts over HTTP(S)
 #  5-Dec-2023 dwp Add support for binary mmCIF (BCIF) reading and writing;
 #                 Set cleanup default to True (delete temporary files and logs after reading)
+# 19-Mar-2026 dwp remove python 2.7 references
 ##
 """
 Python implementation of IoAdapterBase class providing read and write
@@ -119,70 +120,35 @@ class IoAdapterPy(IoAdapterBase):
             #
             fmt = fmt.lower()
             #
-            if sys.version_info[0] > 2:  # Check if using Python version higher than 2
-                if fmt == "mmcif":
-                    if self.__isLocal(filePath):
-                        filePath = self._uncompress(filePath, oPath)
-                        with open(filePath, "r", encoding=encoding, errors=self._readEncodingErrors) as ifh:
-                            pRd = PdbxReader(ifh)
+            if fmt == "mmcif":
+                if self.__isLocal(filePath):
+                    filePath = self._uncompress(filePath, oPath)
+                    with open(filePath, "r", encoding=encoding, errors=self._readEncodingErrors) as ifh:
+                        pRd = PdbxReader(ifh)
+                        pRd.read(containerList, selectList, excludeFlag=excludeFlag)
+                else:  # handle files from the internet...
+                    if filePath.endswith(".gz"):
+                        customHeader = {"Accept-Encoding": "gzip"}
+                        with closing(requests.get(filePath, headers=customHeader, timeout=timeout)) as ifh:
+                            if self._raiseExceptions:
+                                ifh.raise_for_status()
+                            gzit = gzip.GzipFile(fileobj=io.BytesIO(ifh.content))
+                            it = (line.decode(encoding, "ignore") for line in gzit)
+                            pRd = PdbxReader(it)
                             pRd.read(containerList, selectList, excludeFlag=excludeFlag)
-                    else:  # handle files from the internet...
-                        if filePath.endswith(".gz"):
-                            customHeader = {"Accept-Encoding": "gzip"}
-                            with closing(requests.get(filePath, headers=customHeader, timeout=timeout)) as ifh:
-                                if self._raiseExceptions:
-                                    ifh.raise_for_status()
-                                gzit = gzip.GzipFile(fileobj=io.BytesIO(ifh.content))
-                                it = (line.decode(encoding, "ignore") for line in gzit)
-                                pRd = PdbxReader(it)
-                                pRd.read(containerList, selectList, excludeFlag=excludeFlag)
-                        else:
-                            with closing(requests.get(filePath, timeout=timeout)) as ifh:
-                                if self._raiseExceptions:
-                                    ifh.raise_for_status()
-                                it = (line.decode(encoding, "ignore") + "\n" for line in ifh.iter_lines())
-                                pRd = PdbxReader(it)
-                                pRd.read(containerList, selectList, excludeFlag=excludeFlag)
-                elif fmt == "bcif":
-                    # local vs. remote and gzip business is already done in BinaryCifReader
-                    bcifRd = BinaryCifReader(storeStringsAsBytes=storeStringsAsBytes, defaultStringEncoding=defaultStringEncoding)
-                    containerList = bcifRd.deserialize(filePath)
-                else:
-                    logger.error("Unsupported fmt %r. Currently only supports 'mmcif' or 'bcif'.", fmt)
-            else:
-                logger.warning("Support for Python 2 will be deprecated soon. Please use Python 3.")
-                if fmt == "bcif":
-                    logger.error("Support for BCIF reading only available in Python 3.")
-                elif fmt == "mmcif":
-                    if self.__isLocal(filePath):
-                        filePath = self._uncompress(filePath, oPath)
-                        if enforceAscii:
-                            with io.open(filePath, "r", encoding=encoding, errors=self._readEncodingErrors) as ifh:
-                                pRd = PdbxReader(ifh)
-                                pRd.read(containerList, selectList, excludeFlag=excludeFlag)
-                        else:
-                            with open(filePath, "r") as ifh:
-                                pRd = PdbxReader(ifh)
-                                pRd.read(containerList, selectList, excludeFlag=excludeFlag)
                     else:
-                        if filePath.endswith(".gz"):
-                            customHeader = {"Accept-Encoding": "gzip"}
-                            with closing(requests.get(filePath, headers=customHeader, timeout=timeout)) as ifh:
-                                if self._raiseExceptions:
-                                    ifh.raise_for_status()
-                                gzit = gzip.GzipFile(fileobj=io.BytesIO(ifh.content))
-                                it = (line.decode(encoding, "ignore") for line in gzit)
-                                pRd = PdbxReader(it)
-                                pRd.read(containerList, selectList, excludeFlag=excludeFlag)
-                        else:
-                            with closing(requests.get(filePath, timeout=timeout)) as ifh:
-                                if self._raiseExceptions:
-                                    ifh.raise_for_status()
-                                it = (line.decode(encoding, "ignore") + "\n" for line in ifh.iter_lines())
-                                pRd = PdbxReader(it)
-                                pRd.read(containerList, selectList, excludeFlag=excludeFlag)
-                else:
-                    logger.error("Unsupported fmt %r for Python2 installation of mmcif.io.IoAdapterPy. Currently only 'mmcif' is supported. Upgrade to Python3 for 'bcif' support", fmt)
+                        with closing(requests.get(filePath, timeout=timeout)) as ifh:
+                            if self._raiseExceptions:
+                                ifh.raise_for_status()
+                            it = (line.decode(encoding, "ignore") + "\n" for line in ifh.iter_lines())
+                            pRd = PdbxReader(it)
+                            pRd.read(containerList, selectList, excludeFlag=excludeFlag)
+            elif fmt == "bcif":
+                # local vs. remote and gzip business is already done in BinaryCifReader
+                bcifRd = BinaryCifReader(storeStringsAsBytes=storeStringsAsBytes, defaultStringEncoding=defaultStringEncoding)
+                containerList = bcifRd.deserialize(filePath)
+            else:
+                logger.error("Unsupported fmt %r. Currently only supports 'mmcif' or 'bcif'.", fmt)
 
             if cleanUp:
                 self._cleanupFile(lPath, lPath)
@@ -273,73 +239,35 @@ class IoAdapterPy(IoAdapterBase):
             #
             fmt = fmt.lower()
             #
-            if sys.version_info[0] > 2:  # Check if using Python version higher than 2
-                if fmt == "mmcif":
-                    with open(outputFilePath, "w", encoding=encoding) as ofh:
-                        self.__writeFile(
-                            ofh,
-                            containerList,
-                            maxLineLength=maxLineLength,
-                            columnAlignFlag=columnAlignFlag,
-                            lastInOrder=lastInOrder,
-                            selectOrder=selectOrder,
-                            useStopTokens=useStopTokens,
-                            formattingStep=formattingStep,
-                            enforceAscii=enforceAscii,
-                            cnvCharRefs=self._useCharRefs,
-                        )
-                elif fmt == "bcif":
-                    bcifW = BinaryCifWriter(
-                        dictionaryApi=dictionaryApi,
-                        storeStringsAsBytes=storeStringsAsBytes,
-                        defaultStringEncoding=defaultStringEncoding,
-                        applyTypes=applyTypes,
-                        useStringTypes=useStringTypes,
-                        useFloat64=useFloat64,
-                        copyInputData=copyInputData,
-                        ignoreCastErrors=ignoreCastErrors,
+            if fmt == "mmcif":
+                with open(outputFilePath, "w", encoding=encoding) as ofh:
+                    self.__writeFile(
+                        ofh,
+                        containerList,
+                        maxLineLength=maxLineLength,
+                        columnAlignFlag=columnAlignFlag,
+                        lastInOrder=lastInOrder,
+                        selectOrder=selectOrder,
+                        useStopTokens=useStopTokens,
+                        formattingStep=formattingStep,
+                        enforceAscii=enforceAscii,
+                        cnvCharRefs=self._useCharRefs,
                     )
-                    bcifW.serialize(outputFilePath, containerList)
-                else:
-                    logger.error("Unsupported fmt %r. Currently only supports 'mmcif' or 'bcif'.", fmt)
-                    return False
+            elif fmt == "bcif":
+                bcifW = BinaryCifWriter(
+                    dictionaryApi=dictionaryApi,
+                    storeStringsAsBytes=storeStringsAsBytes,
+                    defaultStringEncoding=defaultStringEncoding,
+                    applyTypes=applyTypes,
+                    useStringTypes=useStringTypes,
+                    useFloat64=useFloat64,
+                    copyInputData=copyInputData,
+                    ignoreCastErrors=ignoreCastErrors,
+                )
+                bcifW.serialize(outputFilePath, containerList)
             else:
-                logger.warning("Support for Python 2 will be deprecated soon. Please use Python 3.")
-                if fmt == "bcif":
-                    logger.error("Support for BCIF writing only available in Python 3.")
-                    return False
-                elif fmt == "mmcif":
-                    if enforceAscii:
-                        with io.open(outputFilePath, "w", encoding=encoding) as ofh:
-                            self.__writeFile(
-                                ofh,
-                                containerList,
-                                maxLineLength=maxLineLength,
-                                columnAlignFlag=columnAlignFlag,
-                                lastInOrder=lastInOrder,
-                                selectOrder=selectOrder,
-                                useStopTokens=useStopTokens,
-                                formattingStep=formattingStep,
-                                enforceAscii=enforceAscii,
-                                cnvCharRefs=self._useCharRefs,
-                            )
-                    else:
-                        with open(outputFilePath, "wb") as ofh:
-                            self.__writeFile(
-                                ofh,
-                                containerList,
-                                maxLineLength=maxLineLength,
-                                columnAlignFlag=columnAlignFlag,
-                                lastInOrder=lastInOrder,
-                                selectOrder=selectOrder,
-                                useStopTokens=useStopTokens,
-                                formattingStep=formattingStep,
-                                enforceAscii=enforceAscii,
-                                cnvCharRefs=self._useCharRefs,
-                            )
-                else:
-                    logger.error("Unsupported fmt %r for Python2 installation of mmcif.io.IoAdapterPy. Currently only 'mmcif' is supported. Upgrade to Python3 for 'bcif' support", fmt)
-                    return False
+                logger.error("Unsupported fmt %r. Currently only supports 'mmcif' or 'bcif'.", fmt)
+                return False
             return True
         except Exception as ex:
             if self._raiseExceptions:

--- a/mmcif/io/IoAdapterPy.py
+++ b/mmcif/io/IoAdapterPy.py
@@ -26,7 +26,6 @@ Python implementation of IoAdapterBase class providing read and write
 import gzip
 import io
 import logging
-import sys
 import uuid
 from contextlib import closing
 

--- a/mmcif/io/PdbxWriter.py
+++ b/mmcif/io/PdbxWriter.py
@@ -12,6 +12,7 @@
 #   13-Jan-2018 jdw  add selection attributes lastInOrder=None, selectOrder=None
 #    8-Mar-2018 jdw  make step calc integer division
 #    2-Feb-2019 jdw  adjust formatting removing spurious comments and newlines
+#   19-Mar-2026 dwp  remove python 2.7 references
 ###
 """
 Utilities for writing mmCIF format data and dictionary containers.
@@ -53,11 +54,6 @@ class PdbxWriter(object):
         self.__cnvCharRefs = False
         #
         self.__enforceAscii = False
-        self.__isPy3 = sys.version_info[0] == 3
-        # if self.__isPy3:
-        #     self.__string_types = str
-        # else:
-        #    self.__string_types = basestring
 
     def setSetEnforceAscii(self, boolVal):
         self.__enforceAscii = boolVal
@@ -142,12 +138,6 @@ class PdbxWriter(object):
         try:
             if self.__cnvCharRefs:
                 self.__ofh.write(st.encode("ascii", "xmlcharrefreplace").decode("ascii"))
-            elif not self.__isPy3:
-                if self.__enforceAscii:
-                    self.__ofh.write(st.decode("ascii"))
-                else:
-                    self.__ofh.write(st)
-                    # self.__ofh.write(st.encode('utf-8').decode('utf-8'))
             else:
                 self.__ofh.write(st)
         except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "mmcif"
 description="mmCIF Core Access Library"
 readme = "README.md"
-requires-python = ">= 3.6"
+requires-python = ">= 3.8"
 license = {text = "Apache-2.0"}
 authors = [
  { name = "John Westbrook", email = "john.westbrook@rcsb.org" }	


### PR DESCRIPTION
Support for Python 2 was already removed, but there was still some code left behind that referenced Python 2. These references have now been removed.