### PR TITLE
Drop support for python3.6 compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,11 +26,7 @@ message(STATUS "Python include path set to " ${PYTHON_INCLUDE_DIRS})
 #  -- Build a wrapper library  --
 #
 message(STATUS "Python version is " ${PYTHON_VERSION_STRING})
-if(${PYTHON_VERSION_STRING} VERSION_LESS "3.8")
-  add_subdirectory("modules/pybind11_2_12_1")
-else()
-  add_subdirectory("modules/pybind11")  
-endif()
+add_subdirectory("modules/pybind11")  
 #
 #
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -101,7 +101,9 @@
                          python 3.6 and newer.  Switch to using pyproject.toml for
                          metadata. Build wheels for python 3.8->3.14
 
-24-Nov-2026    V1.1.0  - BinaryCIF encoder corrections: Masked interer encodings
+24-Nov-2025    V1.1.0  - BinaryCIF encoder corrections: Masked interer encodings
                          should default to 0 in array.  Masks should be encoded as
                          as uint_8.  RunLength encoding should specify the incoming
                          data type.
+23-Apr-2026    V1.1.1  - Remove support for python 3.6 as setuptools needed for
+                         pyproject.toml does not function

--- a/mmcif/__init__.py
+++ b/mmcif/__init__.py
@@ -2,6 +2,6 @@ __docformat__ = "google en"
 __author__ = "John Westbrook"
 __email__ = "john.westbrook@rcsb.org"
 __license__ = "Apache 2.0"
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 __apiUrl__ = "https://mmcif.wwpdb.org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "mmcif"
 description="mmCIF Core Access Library"
 readme = "README.md"
-requires-python = ">= 3.6"
+requires-python = ">= 3.8"
 license = {text = "Apache-2.0"}
 authors = [
  { name = "John Westbrook", email = "john.westbrook@rcsb.org" }	


### PR DESCRIPTION
py-mmcif 1.X series cannot compile on python 3.6 due to incompatibility of setuptools.

Remove old pybind11, mark python 3.8 as a minimal version.

Bump version to 1.1.1 

Recommend we back port to 1.0.0 - so we can yank packages that indicate python 3.6 - but cannot be compiled there.
