### PR TITLE
Improve BinaryCIF float chain encoding

### DIFF
--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -8,7 +8,7 @@
 # - FixedPoint support with IntegerPacking, RunLength, and Delta chains.
 # - Column-specific chains for known high-volume float attributes.
 # - Automatic selection of the smallest general FixedPoint chain.
-# - StringArray fallback for high-precision floats that cannot use FixedPoint.
+# - Optional StringArray fallback for high-precision floats (disabled by default).
 ##
 
 import logging
@@ -220,8 +220,8 @@ class BinaryCifEncoders(object):
 
     # True: known coordinate columns use factor 1000 followed by
     #       Delta -> IntegerPacking -> ByteArray.
-    # False: coordinates skip this hard-coded chain and use the general automatic
-    #        factor detection and four-chain comparison instead.
+    # False: coordinates keep factor 1000 but use the general four-chain
+    #        comparison (Delta/RunLength variants) instead.
     USE_COORDINATE_CHAIN = True
 
 
@@ -640,7 +640,6 @@ class BinaryCifEncoders(object):
         """
         return all(-2147483648 <= int(v) <= 2147483647 for v in data)
 
-    # Check whether the current column is one of the Cartesian coordinate columns
     # Check whether the current column is one of the known Cartesian coordinate columns
     def __isCoordinateItem(self, catName, atName):
         """Return True for a coordinate item that uses the factor-1000 hint."""
@@ -693,7 +692,7 @@ class BinaryCifEncoders(object):
         return self.stringArrayMaskedEncoder(stringColDataList, colMaskList)
 
 
-    # scan the column for needed precision (for other than harcoded columns)
+    # scan the column for needed precision (fallback for -coded columns)
     def __getFloatFixedPointFactor(self, colDataList, catName=None, atName=None):
         """Return the smallest exact-enough FixedPoint factor for a float column."""
         if self.__isCoordinateItem(catName, atName):

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -951,12 +951,13 @@ class BinaryCifEncoders(object):
 
         # General floats: auto-detect a safe FixedPoint factor.
         factor = self.__getFloatFixedPointFactor(maskedColDataList)
-        if factor is None:
+        if factor is None:  # no suitable FixedPoint factor was found; use a fallback encoding (string or bytearray)
             if (
                 BCIF_CONFIG.USE_STRING_FLOAT_FALLBACK
                 and self.__shouldUseStringFallbackForFloat(maskedColDataList)
             ):
                 return self.__encodeFloatStringFallback(colDataList, colMaskList)
+            # encode as byte array
             return self.encode(maskedColDataList, fallbackEncoderList, "float")
 
         if BCIF_CONFIG.COMPARE_ALL_FIXED_POINT_CHAINS:

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -1,16 +1,20 @@
 ##
-# File: BinaryCifWrite.py
+# File: BinaryCifWriter.py
 # Date: 15-May-2021  jdw
 #
-#  Write methods and encoders for binary CIF serialization.
+# Write methods and encoders for BinaryCIF serialization.
 #
-#  Updates:
-#
+# Float encoding updates:
+# - FixedPoint support with IntegerPacking, RunLength, and Delta chains.
+# - Column-specific chains for known high-volume float attributes.
+# - Automatic selection of the smallest general FixedPoint chain.
+# - StringArray fallback for high-precision floats that cannot use FixedPoint.
 ##
 
 import logging
 import struct
 import msgpack
+import math
 import warnings
 
 from mmcif.api.DataCategoryTyped import DataCategoryTyped, DataCategoryHints
@@ -87,7 +91,8 @@ class BinaryCifWriter(object):
                         colDataList = cObj.getColumn(ii)
                         dataType = self.__getAttributeType(cObj, atName) if not self.__useStringTypes else "string"
                         logger.debug("catName %r atName %r dataType %r", catName, atName, dataType)
-                        colMaskDict, encodedColDataList, encodingDictL = self.__encodeColumnData(colDataList, dataType)
+                        # Pass category/item names so float columns can use coordinate-specific hints
+                        colMaskDict, encodedColDataList, encodingDictL = self.__encodeColumnData(colDataList, dataType, catName, atName)
                         cols.append(
                             {
                                 self.__toBytes("name"): self.__toBytes(atName),
@@ -109,7 +114,8 @@ class BinaryCifWriter(object):
             logger.exception("Failing with %s", str(e))
         return False
 
-    def __encodeColumnData(self, colDataList, dataType):
+    # Accept category/item names so encoder selection can use column-specific hints
+    def __encodeColumnData(self, colDataList, dataType, catName=None, atName=None):
         colMaskDict = None  # Use None when no mask and not {} - per Mol* implementation
         enc = BinaryCifEncoders(defaultStringEncoding=self.__defaultStringEncoding, storeStringsAsBytes=self.__storeStringsAsBytes, useFloat64=self.__useFloat64)
         #
@@ -117,7 +123,8 @@ class BinaryCifWriter(object):
         typeEncoderD = {"string": "StringArrayMasked", "integer": "IntArrayMasked", "float": "FloatArrayMasked"}
         colMaskList = enc.getMask(colDataList)
         dataEncType = typeEncoderD[dataType]
-        colDataEncoded, colDataEncodingDictL = enc.encodeWithMask(colDataList, colMaskList, dataEncType)
+        # Forward category/item names to the masked encoder
+        colDataEncoded, colDataEncodingDictL = enc.encodeWithMask(colDataList, colMaskList, dataEncType, catName=catName, atName=atName)
         if colMaskList:
             # Mol* indicates that masks should be encoded as if uint_8
             colMaskListTyped = TypedArray(colMaskList, "unsigned_integer_8")
@@ -197,6 +204,140 @@ class BinaryCifEncoders(object):
 
     """
 
+
+    # Float encoding feature switches
+    #
+    # The five individual switches below only apply when the switch is
+    # True. Disabling an individual hard-code does not force ByteArray; it sends
+    # that column through the general automatic FixedPoint chain selection.
+
+
+    # True: enable the new FixedPoint-based float encoding logic and all enabled
+    #       specialized paths below.
+    # False: bypass every float optimization below and encode all floats directly
+    #        with the original float ByteArray behavior.
+    USE_FIXED_POINT_FLOAT_ENCODING = True
+
+    # True: known coordinate columns use factor 1000 followed by
+    #       Delta -> IntegerPacking -> ByteArray.
+    # False: coordinates skip this hard-coded chain and use the general automatic
+    #        factor detection and four-chain comparison instead.
+    USE_COORDINATE_CHAIN = True
+
+
+    # True: the six _atom_site_anisotrop U columns use factor 10000 followed by
+    #       Delta -> IntegerPacking -> ByteArray.
+    # False: those columns skip this hard-code and use the general float path.
+    USE_ANISOTROP_U_CHAIN = True
+
+
+    # True: _ihm_sphere_obj_site.object_radius uses factor 1000 followed by
+    #       IntegerPacking -> ByteArray, without Delta or RunLength.
+    # False: object_radius skips this hard-code and uses the general float path.
+    USE_OBJECT_RADIUS_CHAIN = True
+
+
+    # True: occupancy, B_iso_or_equiv, rmsf, and starting-model B_iso_or_equiv
+    #       use an automatically detected factor followed by
+    #       RunLength -> IntegerPacking -> ByteArray.
+    # False: those four attributes skip the RunLength hint and use the general
+    #        automatic factor detection and four-chain comparison.
+    USE_RUN_LENGTH_FLOAT_HINTS = True
+
+
+    # True: when no safe FixedPoint factor is found and a column contains values
+    #       with 5 or more decimal places, encode it as StringArrayMasked.
+    # False: those high-precision fallback columns use float ByteArray instead.
+    USE_STRING_FLOAT_FALLBACK = False
+
+    COORDINATE_FIXED_POINT_FACTOR = 1000
+
+
+    ANISOTROP_U_FIXED_POINT_FACTOR = 10000
+    OBJECT_RADIUS_FIXED_POINT_FACTOR = 1000
+    MAX_FIXED_POINT_DECIMAL_PLACES = 4
+    STRING_FALLBACK_MIN_DECIMAL_PLACES = 5
+    FIXED_POINT_TOLERANCE = 1.0e-6
+
+    COORDINATE_ITEMS = {
+        # PDB / standard model coordinates
+        "_atom_site.Cartn_x",
+        "_atom_site.Cartn_y",
+        "_atom_site.Cartn_z",
+
+        # PDBx/mmCIF chemical component coordinates
+        "_chem_comp_atom.model_Cartn_x",
+        "_chem_comp_atom.model_Cartn_y",
+        "_chem_comp_atom.model_Cartn_z",
+        "_chem_comp_atom.pdbx_model_Cartn_x_ideal",
+        "_chem_comp_atom.pdbx_model_Cartn_y_ideal",
+        "_chem_comp_atom.pdbx_model_Cartn_z_ideal",
+
+        # PDBx/mmCIF phasing-site coordinates
+        "_phasing_MIR_der_site.Cartn_x",
+        "_phasing_MIR_der_site.Cartn_y",
+        "_phasing_MIR_der_site.Cartn_z",
+        "_pdbx_phasing_MAD_set_site.Cartn_x",
+        "_pdbx_phasing_MAD_set_site.Cartn_y",
+        "_pdbx_phasing_MAD_set_site.Cartn_z",
+
+        # PDBx/mmCIF solvent atom-site mapping coordinates
+        "_pdbx_solvent_atom_site_mapping.Cartn_x",
+        "_pdbx_solvent_atom_site_mapping.Cartn_y",
+        "_pdbx_solvent_atom_site_mapping.Cartn_z",
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_x",
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_y",
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_z",
+
+        # ModelCIF / CSM template coordinates
+        "_ma_template_coord.Cartn_x",
+        "_ma_template_coord.Cartn_y",
+        "_ma_template_coord.Cartn_z",
+
+        # IHM coordinates
+        "_ihm_starting_model_coord.Cartn_x",
+        "_ihm_starting_model_coord.Cartn_y",
+        "_ihm_starting_model_coord.Cartn_z",
+        "_ihm_sphere_obj_site.Cartn_x",
+        "_ihm_sphere_obj_site.Cartn_y",
+        "_ihm_sphere_obj_site.Cartn_z",
+        "_ihm_gaussian_obj_site.mean_Cartn_x",
+        "_ihm_gaussian_obj_site.mean_Cartn_y",
+        "_ihm_gaussian_obj_site.mean_Cartn_z",
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_x",
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_y",
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_z",
+        "_ihm_pseudo_site.Cartn_x",
+        "_ihm_pseudo_site.Cartn_y",
+        "_ihm_pseudo_site.Cartn_z",
+
+        # FLR / FPS coordinates
+        "_flr_FPS_mean_probe_position.mpp_xcoord",
+        "_flr_FPS_mean_probe_position.mpp_ycoord",
+        "_flr_FPS_mean_probe_position.mpp_zcoord",
+        "_flr_FPS_MPP_atom_position.xcoord",
+        "_flr_FPS_MPP_atom_position.ycoord",
+        "_flr_FPS_MPP_atom_position.zcoord",
+    }
+
+    ANISOTROP_U_ITEMS = {
+        "_atom_site_anisotrop.U[1][1]",
+        "_atom_site_anisotrop.U[1][2]",
+        "_atom_site_anisotrop.U[1][3]",
+        "_atom_site_anisotrop.U[2][2]",
+        "_atom_site_anisotrop.U[2][3]",
+        "_atom_site_anisotrop.U[3][3]",
+    }
+
+    RUN_LENGTH_FLOAT_ITEMS = {
+        "_atom_site.occupancy",
+        "_atom_site.B_iso_or_equiv",
+        "_ihm_sphere_obj_site.rmsf",
+        "_ihm_starting_model_coord.B_iso_or_equiv",
+    }
+
+    OBJECT_RADIUS_ITEM = "_ihm_sphere_obj_site.object_radius"
+
     def __init__(self, defaultStringEncoding="utf-8", storeStringsAsBytes=True, useFloat64=False):
         """Instantiate the binary CIF encoder class.
 
@@ -237,9 +378,20 @@ class BinaryCifEncoders(object):
             legacy = True
 
         encDict = None
+        # Track data type changes as chained encoders transform the array
+        currentDataType = dataType
         for encType in encodingTypeList:
+            encArg = None
+            # Allow encoders with parameters, e.g. ("FixedPoint", factor)
+            if isinstance(encType, tuple):
+                encType, encArg = encType
+
             if encType == "ByteArray":
-                colDataList, encDict = self.byteArrayEncoderTyped(colDataList, dataType)
+                colDataList, encDict = self.byteArrayEncoderTyped(colDataList, currentDataType)
+            # FixedPoint converts float values into integer_32 values
+            elif encType == "FixedPoint":
+                colDataList, encDict = self.fixedPointEncoderTyped(colDataList, encArg)
+                currentDataType = "integer"
             elif encType == "Delta":
                 colDataList, encDict = self.deltaEncoderTyped(colDataList)
             elif encType == "RunLength":
@@ -254,7 +406,8 @@ class BinaryCifEncoders(object):
             return colDataList.data, encodingDictL
         return colDataList, encodingDictL
 
-    def encodeWithMask(self, colDataList, colMaskList, encodingType):
+    # Accept category/item names for float-column encoding decisions
+    def encodeWithMask(self, colDataList, colMaskList, encodingType, catName=None, atName=None):
         """Encode the data using the input mask and encoding type returning encoded data and encoding instructions.
 
         Args:
@@ -271,8 +424,9 @@ class BinaryCifEncoders(object):
             encodedColDataList, encodingDictL = self.stringArrayMaskedEncoder(colDataList, colMaskList)
         elif encodingType == "IntArrayMasked":
             encodedColDataList, encodingDictL = self.intArrayMaskedEncoder(colDataList, colMaskList)
+        # Pass category/item names only to the float encoder
         elif encodingType == "FloatArrayMasked":
-            encodedColDataList, encodingDictL = self.floatArrayMaskedEncoder(colDataList, colMaskList)
+            encodedColDataList, encodingDictL = self.floatArrayMaskedEncoder(colDataList, colMaskList, catName=catName, atName=atName)
         else:
             logger.info("unsupported masked encoding %r", encodingType)
         return encodedColDataList, encodingDictL
@@ -434,6 +588,170 @@ class BinaryCifEncoders(object):
             encodedTypedColDataList = TypedArray(encodedColDataList, "integer_32")
             return encodedTypedColDataList, encodingD
 
+    # Convert scaled float values into integer_32 values for later integer encoders
+    def fixedPointEncoderTyped(self, colTypedDataList, factor):
+        """Encode a float array as a 32-bit integer array using FixedPoint.
+
+        Args:
+            colTypedDataList (TypedArray): list of float data (float_32 or float_64)
+            factor (int): multiplier used to convert float values to integers
+
+        Returns:
+            TypedArray: fixed-point encoded integer list (integer_32)
+            dict: binary CIF FixedPoint encoding instructions
+        """
+        if colTypedDataList.dtype and colTypedDataList.dtype not in ["float_32", "float_64"]:
+            raise TypeError("Only float arrays can be encoded with FixedPoint: %s" % colTypedDataList.dtype)
+
+        srcType = colTypedDataList.dtype or ("float_64" if self.__useFloat64 else "float_32")
+        encodedColDataList = [self.__roundLikeMolStar(float(v) * factor) for v in colTypedDataList.data]
+
+        if not self.__fitsInt32(encodedColDataList):
+            raise TypeError("FixedPoint output does not fit in integer_32")
+
+        encodingD = {
+            self.__toBytes("kind"): self.__toBytes("FixedPoint"),
+            self.__toBytes("factor"): factor,
+            self.__toBytes("srcType"): self.__bCifTypeCodeD[srcType],
+        }
+        return TypedArray(encodedColDataList, "integer_32"), encodingD
+
+    # Match Mol* JavaScript rounding behavior during FixedPoint conversion
+    def __roundLikeMolStar(self, value):
+        """Round a float value using JavaScript Math.round-like behavior.
+
+        Args:
+            value (float): input float value
+
+        Returns:
+            int: rounded integer value
+        """
+        return int(math.floor(value + 0.5))
+
+    # Ensure FixedPoint output can safely be stored as integer_32
+    def __fitsInt32(self, data):
+        """Check whether all input values fit in a signed 32-bit integer array.
+
+        Args:
+            data (list): list of integer values
+
+        Returns:
+            bool: True if all values fit in signed 32-bit integer range, otherwise False
+        """
+        return all(-2147483648 <= int(v) <= 2147483647 for v in data)
+
+    # Check whether the current column is one of the Cartesian coordinate columns
+    # Check whether the current column is one of the known Cartesian coordinate columns
+    def __isCoordinateItem(self, catName, atName):
+        """Return True for a coordinate item that uses the factor-1000 hint."""
+        return self.__getItemName(catName, atName) in self.COORDINATE_ITEMS
+
+    def __getItemName(self, catName, atName):
+        """Return normalized _category.attribute item name."""
+        if catName is None or atName is None:
+            return ""
+
+        cat = str(catName)
+        if cat.startswith("_"):
+            cat = cat[1:]
+
+        return "_%s.%s" % (cat, atName)
+
+    def __isAnisotropUItem(self, catName, atName):
+        """Return True for an anisotropic displacement U matrix item."""
+        return self.__getItemName(catName, atName) in self.ANISOTROP_U_ITEMS
+
+    def __shouldUseStringFallbackForFloat(self, colDataList):
+        """Return True when the column requires high-precision float fallback."""
+        for val in colDataList:
+            if val is None:
+                continue
+
+            valueString = str(val).strip()
+            if valueString in self.__unknown:
+                continue
+
+            if "e" in valueString.lower():
+                decimalPlaces = 99
+            elif "." in valueString:
+                decimalPlaces = len(valueString.split(".", 1)[1].rstrip("0"))
+            else:
+                decimalPlaces = 0
+
+            if decimalPlaces >= self.STRING_FALLBACK_MIN_DECIMAL_PLACES:
+                return True
+
+        return False
+
+    def __encodeFloatStringFallback(self, colDataList, colMaskList):
+        """Encode a float fallback column as StringArrayMasked."""
+        if colMaskList:
+            stringColDataList = ["0.0" if m else str(d) for m, d in zip(colMaskList, colDataList)]
+        else:
+            stringColDataList = [str(d) for d in colDataList]
+
+        return self.stringArrayMaskedEncoder(stringColDataList, colMaskList)
+
+
+    # scan the column for needed precision (for other than harcoded columns)
+    def __getFloatFixedPointFactor(self, colDataList, catName=None, atName=None):
+        """Return the smallest exact-enough FixedPoint factor for a float column."""
+        if self.__isCoordinateItem(catName, atName):
+            return self.COORDINATE_FIXED_POINT_FACTOR
+
+        mantissaDigits = 0
+        for val in colDataList:
+            value = float(val)
+            if not math.isfinite(value):
+                return None
+
+            foundDigits = None
+            factor = 1
+            for digits in range(self.MAX_FIXED_POINT_DECIMAL_PLACES + 1):
+                scaledValue = factor * value
+                if abs(round(scaledValue) - scaledValue) <= self.FIXED_POINT_TOLERANCE:
+                    foundDigits = digits
+                    break
+                factor *= 10
+
+            if foundDigits is None:
+                return None
+
+            mantissaDigits = max(mantissaDigits, foundDigits)
+
+        return 10 ** mantissaDigits
+
+    # Try each FixedPoint integer chain and keep the smallest byte output
+    def __encodeBestFixedPointChain(self, colDataList, factor):
+        """Try the four FixedPoint integer chains and return the smallest output."""
+        candidateEncoderLists = [
+            [("FixedPoint", factor), "IntegerPacking", "ByteArray"],
+            [("FixedPoint", factor), "RunLength", "IntegerPacking", "ByteArray"],
+            [("FixedPoint", factor), "Delta", "IntegerPacking", "ByteArray"],
+            [("FixedPoint", factor), "Delta", "RunLength", "IntegerPacking", "ByteArray"],
+        ]
+
+        best = None
+        for encoderList in candidateEncoderLists:
+            try:
+                encodedColDataList, encodingDictL = self.encode(list(colDataList), encoderList, "float")
+                encodedData = encodedColDataList.data if isinstance(encodedColDataList, TypedArray) else encodedColDataList
+                size = len(encodedData)
+
+                if best is None or size < best[0]:
+                    best = (size, encodedColDataList, encodingDictL)
+            except Exception as e:
+                logger.debug("Skipping float encoder chain %r: %s", encoderList, str(e))
+
+        if best is None:
+            return None, None
+
+        return best[1], best[2]
+
+
+
+
+
     def stringArrayMaskedEncoder(self, colDataList, colMaskList):
         """Encode the input data column (string) along with the incompleteness mask.
 
@@ -497,24 +815,86 @@ class BinaryCifEncoders(object):
         encodedColDataList, encodingDictL = self.encode(maskedColDataList, integerEncoderList, "integer")
         return encodedColDataList, encodingDictL
 
-    def floatArrayMaskedEncoder(self, colDataList, colMaskList):
-        """Encode the input data column (float) along with the incompleteness mask.
+    # Encode float columns with FixedPoint chains instead of ByteArray-only when safe
+    def __encodeFixedPointChainOrFallback(self, colDataList, factor, encoderList, itemName):
+        """Run one FixedPoint chain, falling back to float ByteArray when unsafe."""
+        try:
+            numericValues = [float(v) for v in colDataList]
 
-        Args:
-            colDataList (list): input data column (string)
-            colMaskList (list): incompleteness mask
+            if not all(math.isfinite(v) for v in numericValues):
+                return self.encode(colDataList, ["ByteArray"], "float")
 
-        Returns:
-            (list, list): encoded data column, list of encoding instructions
-        """
-        floatEncoderList = ["ByteArray"]
+            fixedPointValues = [
+                self.__roundLikeMolStar(v * factor)
+                for v in numericValues
+            ]
+            if not self.__fitsInt32(fixedPointValues):
+                return self.encode(colDataList, ["ByteArray"], "float")
 
+            return self.encode(colDataList, encoderList, "float")
+        except Exception as e:
+            logger.debug("Falling back from the fixed float chain for %s: %s", itemName, str(e))
+            return self.encode(colDataList, ["ByteArray"], "float")
+
+    def floatArrayMaskedEncoder(self, colDataList, colMaskList, catName=None, atName=None):
+        """Encode a float column, preserving its incompleteness mask."""
         if colMaskList:
             maskedColDataList = [0.0 if m else d for m, d in zip(colMaskList, colDataList)]
         else:
             maskedColDataList = colDataList
-        encodedColDataList, encodingDictL = self.encode(maskedColDataList, floatEncoderList, "float")
+
+        fallbackEncoderList = ["ByteArray"]
+        if not self.USE_FIXED_POINT_FLOAT_ENCODING:
+            return self.encode(maskedColDataList, fallbackEncoderList, "float")
+
+        itemName = self.__getItemName(catName, atName)
+
+        # Known coordinate columns: factor 1000 + Delta.
+        if self.USE_COORDINATE_CHAIN and self.__isCoordinateItem(catName, atName):
+            factor = self.COORDINATE_FIXED_POINT_FACTOR
+            encoderList = [("FixedPoint", factor), "Delta", "IntegerPacking", "ByteArray"]
+            return self.__encodeFixedPointChainOrFallback(maskedColDataList, factor, encoderList, itemName)
+
+        # Anisotropic U columns: factor 10000 + Delta.
+        if self.USE_ANISOTROP_U_CHAIN and self.__isAnisotropUItem(catName, atName):
+            factor = self.ANISOTROP_U_FIXED_POINT_FACTOR
+            encoderList = [("FixedPoint", factor), "Delta", "IntegerPacking", "ByteArray"]
+            return self.__encodeFixedPointChainOrFallback(maskedColDataList, factor, encoderList, itemName)
+
+        # IHM sphere radius: factor 1000 without Delta or RunLength.
+        if self.USE_OBJECT_RADIUS_CHAIN and itemName == self.OBJECT_RADIUS_ITEM:
+            factor = self.OBJECT_RADIUS_FIXED_POINT_FACTOR
+            encoderList = [("FixedPoint", factor), "IntegerPacking", "ByteArray"]
+            return self.__encodeFixedPointChainOrFallback(maskedColDataList, factor, encoderList, itemName)
+
+        # Repeated high-volume float items: automatic factor + RunLength.
+        if self.USE_RUN_LENGTH_FLOAT_HINTS and itemName in self.RUN_LENGTH_FLOAT_ITEMS:
+            factor = self.__getFloatFixedPointFactor(maskedColDataList, catName=catName, atName=atName)
+            if factor is None:
+                if self.USE_STRING_FLOAT_FALLBACK and self.__shouldUseStringFallbackForFloat(maskedColDataList):
+                    return self.__encodeFloatStringFallback(colDataList, colMaskList)
+                return self.encode(maskedColDataList, fallbackEncoderList, "float")
+
+            encoderList = [("FixedPoint", factor), "RunLength", "IntegerPacking", "ByteArray"]
+            return self.__encodeFixedPointChainOrFallback(maskedColDataList, factor, encoderList, itemName)
+
+        # General floats: detect a factor and choose the smallest of four chains.
+        factor = self.__getFloatFixedPointFactor(maskedColDataList, catName=catName, atName=atName)
+        if factor is None:
+            if self.USE_STRING_FLOAT_FALLBACK and self.__shouldUseStringFallbackForFloat(maskedColDataList):
+                return self.__encodeFloatStringFallback(colDataList, colMaskList)
+            return self.encode(maskedColDataList, fallbackEncoderList, "float")
+
+        fixedPointValues = [self.__roundLikeMolStar(float(v) * factor) for v in maskedColDataList]
+        if not self.__fitsInt32(fixedPointValues):
+            return self.encode(maskedColDataList, fallbackEncoderList, "float")
+
+        encodedColDataList, encodingDictL = self.__encodeBestFixedPointChain(maskedColDataList, factor)
+        if encodedColDataList is None:
+            return self.encode(maskedColDataList, fallbackEncoderList, "float")
+
         return encodedColDataList, encodingDictL
+
 
     def getMask(self, colDataList):
         """Create an incompleteness mask list identifying missing/omitted values in the input data column.

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -17,11 +17,14 @@
 #   - _FORCE_STRING_ATTRS overrides auto-detection for char-typed attributes
 #     that look numeric (e.g. _audit_conform.dict_version = "5.281").
 #
-# Float encoding updates:
-# - FixedPoint support with IntegerPacking, RunLength, and Delta chains.
-# - Column-specific chains for known high-volume float attributes.
-# - Automatic selection of the smallest general FixedPoint chain.
-# - Optional StringArray fallback for high-precision floats (disabled by default).
+#   15-Jul-2026 ym
+#   - Added FixedPoint float encoding with IntegerPacking, RunLength, and Delta
+#     chains.
+#   - Added configurable item-specific float encoding and automatic selection
+#     of the smallest general FixedPoint chain.
+#   - Moved BinaryCIF float-encoding configuration to mmcif.io.config.
+#   - Added optional StringArray fallback for high-precision floats, disabled
+#     by default.
 ##
 
 import logging
@@ -33,6 +36,7 @@ import warnings
 from mmcif.api.DataCategoryTyped import DataCategoryTyped, DataCategoryHints
 from mmcif.api.PdbxContainers import CifName
 from mmcif.io.BinaryCifReader import BinaryCifDecoders
+from mmcif.io.config import BCIF_CONFIG
 
 from mmcif.io.bcif_type_detector import classify_column
 
@@ -142,7 +146,7 @@ class BinaryCifWriter(object):
             }
             with open(filePath, "wb") as ofh:
                 msgpack.pack(data, ofh)
-            
+
             return True
         except Exception as e:
             logger.exception("Failing with %s", str(e))
@@ -176,7 +180,6 @@ class BinaryCifWriter(object):
                 else (v if isinstance(v, float) else float(v))
                 for v in colDataList
             ]
-        
 
         dataEncType = typeEncoderD[dataType]
         # Forward category/item names to the masked encoder
@@ -236,15 +239,15 @@ class BinaryCifWriter(object):
         "_struct_conn.ptnr2_auth_seq_id",
         "_struct_sheet_range.beg_auth_seq_id",
         "_struct_sheet_range.end_auth_seq_id",
-        })
-    
+    })
+
     _FORCE_FLOAT_ATTRS = frozenset({
         "_atom_site.Cartn_x",
         "_atom_site.Cartn_y",
         "_atom_site.Cartn_z",
         "_atom_site.occupancy",
         "_atom_site.B_iso_or_equiv",
- 
+
         # PDBx/mmCIF chemical component Cartesian coordinates
         "_chem_comp_atom.model_Cartn_x",
         "_chem_comp_atom.model_Cartn_y",
@@ -309,7 +312,7 @@ class BinaryCifWriter(object):
         "_flr_FPS_MPP_atom_position.ycoord",
         "_flr_FPS_MPP_atom_position.zcoord",
     })
-    
+
     def __getForcedAttributeType(self, catName, atName):
         """
         Return forced data type for known attributes.
@@ -349,7 +352,7 @@ class BinaryCifWriter(object):
                     )
             else:
                 dataType = self.__dch.getPdbxItemType(cifDataType)
-            
+
             # Mol* integer hints only apply to the dictionary-driven path.
             # In auto-detect mode, every attribute inMolStarIntHints() covers
             # is already present in _FORCE_INTEGER_ATTRS, so this is a no-op
@@ -406,140 +409,6 @@ class BinaryCifEncoders(object):
 
     """
 
-
-    # Float encoding feature switches
-    #
-    # The five individual switches below only apply when the switch is
-    # True. Disabling an individual hard-code does not force ByteArray; it sends
-    # that column through the general automatic FixedPoint chain selection.
-
-
-    # True: enable the new FixedPoint-based float encoding logic and all enabled
-    #       specialized paths below.
-    # False: bypass every float optimization below and encode all floats directly
-    #        with the original float ByteArray behavior.
-    USE_FIXED_POINT_FLOAT_ENCODING = True
-
-    # True: known coordinate columns use factor 1000 followed by
-    #       Delta -> IntegerPacking -> ByteArray.
-    # False: coordinates keep factor 1000 but use the general four-chain
-    #        comparison (Delta/RunLength variants) instead.
-    USE_COORDINATE_CHAIN = True
-
-
-    # True: the six _atom_site_anisotrop U columns use factor 10000 followed by
-    #       Delta -> IntegerPacking -> ByteArray.
-    # False: those columns skip this hard-code and use the general float path.
-    USE_ANISOTROP_U_CHAIN = True
-
-
-    # True: _ihm_sphere_obj_site.object_radius uses factor 1000 followed by
-    #       IntegerPacking -> ByteArray, without Delta or RunLength.
-    # False: object_radius skips this hard-code and uses the general float path.
-    USE_OBJECT_RADIUS_CHAIN = True
-
-
-    # True: occupancy, B_iso_or_equiv, rmsf, and starting-model B_iso_or_equiv
-    #       use an automatically detected factor followed by
-    #       RunLength -> IntegerPacking -> ByteArray.
-    # False: those four attributes skip the RunLength hint and use the general
-    #        automatic factor detection and four-chain comparison.
-    USE_RUN_LENGTH_FLOAT_HINTS = True
-
-
-    # True: when no safe FixedPoint factor is found and a column contains values
-    #       with 5 or more decimal places, encode it as StringArrayMasked.
-    # False: those high-precision fallback columns use float ByteArray instead.
-    USE_STRING_FLOAT_FALLBACK = False
-
-    COORDINATE_FIXED_POINT_FACTOR = 1000
-
-
-    ANISOTROP_U_FIXED_POINT_FACTOR = 10000
-    OBJECT_RADIUS_FIXED_POINT_FACTOR = 1000
-    MAX_FIXED_POINT_DECIMAL_PLACES = 4
-    STRING_FALLBACK_MIN_DECIMAL_PLACES = 5
-    FIXED_POINT_TOLERANCE = 1.0e-6
-
-    COORDINATE_ITEMS = frozenset({
-        # PDB / standard model coordinates
-        "_atom_site.Cartn_x",
-        "_atom_site.Cartn_y",
-        "_atom_site.Cartn_z",
-
-        # PDBx/mmCIF chemical component coordinates
-        "_chem_comp_atom.model_Cartn_x",
-        "_chem_comp_atom.model_Cartn_y",
-        "_chem_comp_atom.model_Cartn_z",
-        "_chem_comp_atom.pdbx_model_Cartn_x_ideal",
-        "_chem_comp_atom.pdbx_model_Cartn_y_ideal",
-        "_chem_comp_atom.pdbx_model_Cartn_z_ideal",
-
-        # PDBx/mmCIF phasing-site coordinates
-        "_phasing_MIR_der_site.Cartn_x",
-        "_phasing_MIR_der_site.Cartn_y",
-        "_phasing_MIR_der_site.Cartn_z",
-        "_pdbx_phasing_MAD_set_site.Cartn_x",
-        "_pdbx_phasing_MAD_set_site.Cartn_y",
-        "_pdbx_phasing_MAD_set_site.Cartn_z",
-
-        # PDBx/mmCIF solvent atom-site mapping coordinates
-        "_pdbx_solvent_atom_site_mapping.Cartn_x",
-        "_pdbx_solvent_atom_site_mapping.Cartn_y",
-        "_pdbx_solvent_atom_site_mapping.Cartn_z",
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_x",
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_y",
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_z",
-
-        # ModelCIF / CSM template coordinates
-        "_ma_template_coord.Cartn_x",
-        "_ma_template_coord.Cartn_y",
-        "_ma_template_coord.Cartn_z",
-
-        # IHM coordinates
-        "_ihm_starting_model_coord.Cartn_x",
-        "_ihm_starting_model_coord.Cartn_y",
-        "_ihm_starting_model_coord.Cartn_z",
-        "_ihm_sphere_obj_site.Cartn_x",
-        "_ihm_sphere_obj_site.Cartn_y",
-        "_ihm_sphere_obj_site.Cartn_z",
-        "_ihm_gaussian_obj_site.mean_Cartn_x",
-        "_ihm_gaussian_obj_site.mean_Cartn_y",
-        "_ihm_gaussian_obj_site.mean_Cartn_z",
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_x",
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_y",
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_z",
-        "_ihm_pseudo_site.Cartn_x",
-        "_ihm_pseudo_site.Cartn_y",
-        "_ihm_pseudo_site.Cartn_z",
-
-        # FLR / FPS coordinates
-        "_flr_FPS_mean_probe_position.mpp_xcoord",
-        "_flr_FPS_mean_probe_position.mpp_ycoord",
-        "_flr_FPS_mean_probe_position.mpp_zcoord",
-        "_flr_FPS_MPP_atom_position.xcoord",
-        "_flr_FPS_MPP_atom_position.ycoord",
-        "_flr_FPS_MPP_atom_position.zcoord",
-    })
-
-    ANISOTROP_U_ITEMS = frozenset({
-        "_atom_site_anisotrop.U[1][1]",
-        "_atom_site_anisotrop.U[1][2]",
-        "_atom_site_anisotrop.U[1][3]",
-        "_atom_site_anisotrop.U[2][2]",
-        "_atom_site_anisotrop.U[2][3]",
-        "_atom_site_anisotrop.U[3][3]",
-    })
-
-    RUN_LENGTH_FLOAT_ITEMS = frozenset({
-        "_atom_site.occupancy",
-        "_atom_site.B_iso_or_equiv",
-        "_ihm_sphere_obj_site.rmsf",
-        "_ihm_starting_model_coord.B_iso_or_equiv",
-    })
-
-    OBJECT_RADIUS_ITEM = "_ihm_sphere_obj_site.object_radius"
-
     def __init__(self, defaultStringEncoding="utf-8", storeStringsAsBytes=True, useFloat64=False):
         """Instantiate the binary CIF encoder class.
 
@@ -580,7 +449,9 @@ class BinaryCifEncoders(object):
             legacy = True
 
         encDict = None
-        # Track data type changes as chained encoders transform the array
+        # Chained encoders can change the array's data type. FixedPoint converts
+        # float values to integer_32 values, so a later ByteArray step must encode
+        # the current integer type rather than the original float input type.
         currentDataType = dataType
         for encType in encodingTypeList:
             encArg = None
@@ -613,9 +484,14 @@ class BinaryCifEncoders(object):
         """Encode the data using the input mask and encoding type returning encoded data and encoding instructions.
 
         Args:
-            colDataList (string): input data column
+            colDataList (list): input data column
             colMaskList (list): incompleteness mask for the input data column
-            encodingType (string): encoding type to apply (StringArrayMask, IntArrayMasked, FloatArrayMasked)
+            encodingType (string): encoding type to apply
+                (StringArrayMasked, IntArrayMasked, FloatArrayMasked)
+            catName (str, optional): category name used for float-column
+                encoding decisions. Defaults to None.
+            atName (str, optional): attribute name used for float-column
+                encoding decisions. Defaults to None.
 
         Returns:
             (list, list ): encoded data column, list of encoding instructions
@@ -801,6 +677,10 @@ class BinaryCifEncoders(object):
         Returns:
             TypedArray: fixed-point encoded integer list (integer_32)
             dict: binary CIF FixedPoint encoding instructions
+
+        Raises:
+            TypeError: if the input is not a float array or the scaled
+                FixedPoint values cannot be represented as signed integer_32.
         """
         if colTypedDataList.dtype and colTypedDataList.dtype not in ["float_32", "float_64"]:
             raise TypeError("Only float arrays can be encoded with FixedPoint: %s" % colTypedDataList.dtype)
@@ -842,25 +722,16 @@ class BinaryCifEncoders(object):
         """
         return all(-2147483648 <= int(v) <= 2147483647 for v in data)
 
-    # Check whether the current column is one of the known Cartesian coordinate columns
-    def __isCoordinateItem(self, catName, atName):
-        """Return True for a coordinate item that uses the factor-1000 hint."""
-        return self.__getItemName(catName, atName) in self.COORDINATE_ITEMS
-
     def __getItemName(self, catName, atName):
         """Return normalized _category.attribute item name."""
         if catName is None or atName is None:
             return ""
 
-        cat = str(catName)
+        cat = catName
         if cat.startswith("_"):
             cat = cat[1:]
 
         return "_%s.%s" % (cat, atName)
-
-    def __isAnisotropUItem(self, catName, atName):
-        """Return True for an anisotropic displacement U matrix item."""
-        return self.__getItemName(catName, atName) in self.ANISOTROP_U_ITEMS
 
     def __shouldUseStringFallbackForFloat(self, colDataList):
         """Return True when the column requires high-precision float fallback."""
@@ -879,7 +750,7 @@ class BinaryCifEncoders(object):
             else:
                 decimalPlaces = 0
 
-            if decimalPlaces >= self.STRING_FALLBACK_MIN_DECIMAL_PLACES:
+            if decimalPlaces >= BCIF_CONFIG.STRING_FALLBACK_MIN_DECIMAL_PLACES:
                 return True
 
         return False
@@ -893,12 +764,9 @@ class BinaryCifEncoders(object):
 
         return self.stringArrayMaskedEncoder(stringColDataList, colMaskList)
 
-
-    # scan the column for needed precision (fallback for -coded columns)
-    def __getFloatFixedPointFactor(self, colDataList, catName=None, atName=None):
+    # Scan the column for the precision needed by general float items.
+    def __getFloatFixedPointFactor(self, colDataList):
         """Return the smallest exact-enough FixedPoint factor for a float column."""
-        if self.__isCoordinateItem(catName, atName):
-            return self.COORDINATE_FIXED_POINT_FACTOR
 
         mantissaDigits = 0
         for val in colDataList:
@@ -908,9 +776,9 @@ class BinaryCifEncoders(object):
 
             foundDigits = None
             factor = 1
-            for digits in range(self.MAX_FIXED_POINT_DECIMAL_PLACES + 1):
+            for digits in range(BCIF_CONFIG.MAX_FIXED_POINT_DECIMAL_PLACES + 1):
                 scaledValue = factor * value
-                if abs(round(scaledValue) - scaledValue) <= self.FIXED_POINT_TOLERANCE:
+                if abs(round(scaledValue) - scaledValue) <= BCIF_CONFIG.FIXED_POINT_TOLERANCE:
                     foundDigits = digits
                     break
                 factor *= 10
@@ -932,26 +800,26 @@ class BinaryCifEncoders(object):
             [("FixedPoint", factor), "Delta", "RunLength", "IntegerPacking", "ByteArray"],
         ]
 
-        best = None
+        bestSize = None
+        bestEncodedColDataList = None
+        bestEncodingDictL = None
         for encoderList in candidateEncoderLists:
             try:
                 encodedColDataList, encodingDictL = self.encode(list(colDataList), encoderList, "float")
                 encodedData = encodedColDataList.data if isinstance(encodedColDataList, TypedArray) else encodedColDataList
                 size = len(encodedData)
 
-                if best is None or size < best[0]:
-                    best = (size, encodedColDataList, encodingDictL)
+                if bestSize is None or size < bestSize:
+                    bestSize = size
+                    bestEncodedColDataList = encodedColDataList
+                    bestEncodingDictL = encodingDictL
             except Exception as e:
                 logger.debug("Skipping float encoder chain %r: %s", encoderList, str(e))
 
-        if best is None:
+        if bestSize is None:
             return None, None
 
-        return best[1], best[2]
-
-
-
-
+        return bestEncodedColDataList, bestEncodingDictL
 
     def stringArrayMaskedEncoder(self, colDataList, colMaskList):
         """Encode the input data column (string) along with the incompleteness mask.
@@ -1018,7 +886,7 @@ class BinaryCifEncoders(object):
 
     # Encode float columns with FixedPoint chains instead of ByteArray-only when safe
     def __encodeFixedPointChainOrFallback(self, colDataList, factor, encoderList, itemName):
-        """Run one FixedPoint chain, falling back to float ByteArray when unsafe."""
+        """Run one FixedPoint chain, falling back to float ByteArray when FixedPoint is unsafe or the chain raises."""
         try:
             numericValues = [float(v) for v in colDataList]
 
@@ -1045,57 +913,80 @@ class BinaryCifEncoders(object):
             maskedColDataList = colDataList
 
         fallbackEncoderList = ["ByteArray"]
-        if not self.USE_FIXED_POINT_FLOAT_ENCODING:
-            return self.encode(maskedColDataList, fallbackEncoderList, "float")
-
         itemName = self.__getItemName(catName, atName)
+        itemConfig = BCIF_CONFIG.get_float_item_config(itemName)
 
-        # Known coordinate columns: factor 1000 + Delta.
-        if self.USE_COORDINATE_CHAIN and self.__isCoordinateItem(catName, atName):
-            factor = self.COORDINATE_FIXED_POINT_FACTOR
-            encoderList = [("FixedPoint", factor), "Delta", "IntegerPacking", "ByteArray"]
-            return self.__encodeFixedPointChainOrFallback(maskedColDataList, factor, encoderList, itemName)
+        # Forced float items with a fixed factor always use their configured
+        # factor and encoder chain.
+        if itemConfig is not None and itemConfig.factor is not None:
+            factor = itemConfig.factor
+            encoderList = BCIF_CONFIG.get_float_encoder_list(itemName)
+            return self.__encodeFixedPointChainOrFallback(
+                maskedColDataList,
+                factor,
+                encoderList,
+                itemName,
+            )
 
-        # Anisotropic U columns: factor 10000 + Delta.
-        if self.USE_ANISOTROP_U_CHAIN and self.__isAnisotropUItem(catName, atName):
-            factor = self.ANISOTROP_U_FIXED_POINT_FACTOR
-            encoderList = [("FixedPoint", factor), "Delta", "IntegerPacking", "ByteArray"]
-            return self.__encodeFixedPointChainOrFallback(maskedColDataList, factor, encoderList, itemName)
-
-        # IHM sphere radius: factor 1000 without Delta or RunLength.
-        if self.USE_OBJECT_RADIUS_CHAIN and itemName == self.OBJECT_RADIUS_ITEM:
-            factor = self.OBJECT_RADIUS_FIXED_POINT_FACTOR
-            encoderList = [("FixedPoint", factor), "IntegerPacking", "ByteArray"]
-            return self.__encodeFixedPointChainOrFallback(maskedColDataList, factor, encoderList, itemName)
-
-        # Repeated high-volume float items: automatic factor + RunLength.
-        if self.USE_RUN_LENGTH_FLOAT_HINTS and itemName in self.RUN_LENGTH_FLOAT_ITEMS:
-            factor = self.__getFloatFixedPointFactor(maskedColDataList, catName=catName, atName=atName)
+        # Selected high-volume float items may use their configured
+        # auto-detected factor and RunLength chain.
+        if (
+            itemConfig is not None
+            and itemConfig.factor is None
+            and BCIF_CONFIG.USE_RUN_LENGTH_FLOAT_HINTS
+        ):
+            factor = self.__getFloatFixedPointFactor(maskedColDataList)
             if factor is None:
-                if self.USE_STRING_FLOAT_FALLBACK and self.__shouldUseStringFallbackForFloat(maskedColDataList):
+                if (
+                    BCIF_CONFIG.USE_STRING_FLOAT_FALLBACK
+                    and self.__shouldUseStringFallbackForFloat(maskedColDataList)
+                ):
                     return self.__encodeFloatStringFallback(colDataList, colMaskList)
                 return self.encode(maskedColDataList, fallbackEncoderList, "float")
 
-            encoderList = [("FixedPoint", factor), "RunLength", "IntegerPacking", "ByteArray"]
-            return self.__encodeFixedPointChainOrFallback(maskedColDataList, factor, encoderList, itemName)
+            encoderList = [
+                ("FixedPoint", factor),
+                *itemConfig.encoderList,
+            ]
+            return self.__encodeFixedPointChainOrFallback(
+                maskedColDataList,
+                factor,
+                encoderList,
+                itemName,
+            )
 
-        # General floats: detect a factor and choose the smallest of four chains.
-        factor = self.__getFloatFixedPointFactor(maskedColDataList, catName=catName, atName=atName)
+        # General floats: auto-detect a safe FixedPoint factor.
+        factor = self.__getFloatFixedPointFactor(maskedColDataList)
         if factor is None:
-            if self.USE_STRING_FLOAT_FALLBACK and self.__shouldUseStringFallbackForFloat(maskedColDataList):
+            if (
+                BCIF_CONFIG.USE_STRING_FLOAT_FALLBACK
+                and self.__shouldUseStringFallbackForFloat(maskedColDataList)
+            ):
                 return self.__encodeFloatStringFallback(colDataList, colMaskList)
             return self.encode(maskedColDataList, fallbackEncoderList, "float")
 
-        fixedPointValues = [self.__roundLikeMolStar(float(v) * factor) for v in maskedColDataList]
-        if not self.__fitsInt32(fixedPointValues):
-            return self.encode(maskedColDataList, fallbackEncoderList, "float")
+        if BCIF_CONFIG.COMPARE_ALL_FIXED_POINT_CHAINS:
+            encodedColDataList, encodingDictL = self.__encodeBestFixedPointChain(
+                maskedColDataList,
+                factor,
+            )
+            if encodedColDataList is None:
+                return self.encode(maskedColDataList, fallbackEncoderList, "float")
+            return encodedColDataList, encodingDictL
 
-        encodedColDataList, encodingDictL = self.__encodeBestFixedPointChain(maskedColDataList, factor)
-        if encodedColDataList is None:
-            return self.encode(maskedColDataList, fallbackEncoderList, "float")
-
-        return encodedColDataList, encodingDictL
-
+        encoderList = [
+            ("FixedPoint", factor),
+            "Delta",
+            "RunLength",
+            "IntegerPacking",
+            "ByteArray",
+        ]
+        return self.__encodeFixedPointChainOrFallback(
+            maskedColDataList,
+            factor,
+            encoderList,
+            itemName,
+        )
 
     def getMask(self, colDataList):
         """Create an incompleteness mask list identifying missing/omitted values in the input data column.

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -259,7 +259,7 @@ class BinaryCifEncoders(object):
     STRING_FALLBACK_MIN_DECIMAL_PLACES = 5
     FIXED_POINT_TOLERANCE = 1.0e-6
 
-    COORDINATE_ITEMS = {
+    COORDINATE_ITEMS = frozenset({
         # PDB / standard model coordinates
         "_atom_site.Cartn_x",
         "_atom_site.Cartn_y",
@@ -318,23 +318,23 @@ class BinaryCifEncoders(object):
         "_flr_FPS_MPP_atom_position.xcoord",
         "_flr_FPS_MPP_atom_position.ycoord",
         "_flr_FPS_MPP_atom_position.zcoord",
-    }
+    })
 
-    ANISOTROP_U_ITEMS = {
+    ANISOTROP_U_ITEMS = frozenset({
         "_atom_site_anisotrop.U[1][1]",
         "_atom_site_anisotrop.U[1][2]",
         "_atom_site_anisotrop.U[1][3]",
         "_atom_site_anisotrop.U[2][2]",
         "_atom_site_anisotrop.U[2][3]",
         "_atom_site_anisotrop.U[3][3]",
-    }
+    })
 
-    RUN_LENGTH_FLOAT_ITEMS = {
+    RUN_LENGTH_FLOAT_ITEMS = frozenset({
         "_atom_site.occupancy",
         "_atom_site.B_iso_or_equiv",
         "_ihm_sphere_obj_site.rmsf",
         "_ihm_starting_model_coord.B_iso_or_equiv",
-    }
+    })
 
     OBJECT_RADIUS_ITEM = "_ihm_sphere_obj_site.object_radius"
 

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -727,11 +727,10 @@ class BinaryCifEncoders(object):
         if catName is None or atName is None:
             return ""
 
-        cat = catName
-        if cat.startswith("_"):
-            cat = cat[1:]
-
-        return "_%s.%s" % (cat, atName)
+        if catName.startswith("_"):
+            return "%s.%s" % (catName, atName)
+        else:
+            return "_%s.%s" % (catName, atName)
 
     def __shouldUseStringFallbackForFloat(self, colDataList):
         """Return True when the column requires high-precision float fallback."""
@@ -928,13 +927,8 @@ class BinaryCifEncoders(object):
                 itemName,
             )
 
-        # Selected high-volume float items may use their configured
-        # auto-detected factor and RunLength chain.
-        if (
-            itemConfig is not None
-            and itemConfig.factor is None
-            and BCIF_CONFIG.USE_RUN_LENGTH_FLOAT_HINTS
-        ):
+        # Configured auto-factor float items use their configured encoder chain.
+        if itemConfig is not None and itemConfig.factor is None:
             factor = self.__getFloatFixedPointFactor(maskedColDataList)
             if factor is None:
                 if (

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -76,12 +76,6 @@ class BinaryCifEncodingConfig:
     # Global float-encoding switches
     # -----------------------------------------------------------------------
 
-    # True:  use the configured RunLength encoding chains for selected
-    #        high-volume float items.
-    # False: treat those items as general floats and use automatic factor
-    #        detection and general FixedPoint chain selection.
-    USE_RUN_LENGTH_FLOAT_HINTS = True
-
     # True:  when no safe FixedPoint factor is found (general/undetected
     #        items only) and a column contains values with 5 or more decimal
     #        places, encode it as StringArrayMasked.

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -179,6 +179,8 @@ class BinaryCifEncodingConfig:
         "_ihm_sphere_obj_site.object_radius": FloatEncodingConfig(1000, ["FixedPoint", "IntegerPacking", "ByteArray"]),
 
         # ---- High-volume float items: factor auto-detected from data, RunLength chain ----
+        # NOTE: Setting factor=None means the caller is expected to auto-detect a safe factor from the column's data,
+        #       and prepend the "FixedPoint" step to the encoder list with that factor.
         "_atom_site.occupancy": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
         "_atom_site.B_iso_or_equiv": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
         "_ihm_sphere_obj_site.rmsf": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -1,0 +1,231 @@
+##
+# File: config.py
+# Date: 06-Jul-2026
+#
+# Configuration settings, primarily for BinaryCifWriter.py encoding behavior.
+#
+##
+
+_UNSET = object()
+
+
+def _set_float_item_names(itemConfigs):
+    """Populate each FloatEncodingConfig.name from its dictionary key."""
+    for itemName, itemConfig in itemConfigs.items():
+        itemConfig.name = itemName
+    return itemConfigs
+
+
+class FloatEncodingConfig:
+    """Describes how a single float data item should be encoded.
+
+    All items tracked via FloatEncodingConfig are assumed to be floats.
+
+    Attributes:
+        name (str): full item name, e.g. "_atom_site.Cartn_x"
+        factor (int or None): FixedPoint scaling factor.
+            - Not provided (default) -> 1000. (This is what _UNSET is for.)
+            - Provided as None -> no fixed factor; the caller is expected to
+              auto-detect a safe factor from the column's data (used below
+              for a handful of high-volume items that need this today).
+            - Provided as an int -> always use that fixed factor.
+        encoderList (list or None): the encoder chain for this item, e.g.
+            ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]. Include
+            the literal string "FixedPoint" wherever the FixedPoint step
+            belongs in the chain; get_float_encoder_list() will substitute in
+            the actual factor. Defaults to None (no pre-determined chain).
+    """
+
+    def __init__(self, factor=_UNSET, encoderList=None, name=None):
+        self.name = name
+        self.factor = 1000 if factor is _UNSET else factor
+        self.encoderList = encoderList
+
+    def get_float_encoder_list(self):
+        """Return this item's encoder list, with any "FixedPoint" entry
+        replaced by the tuple ("FixedPoint", self.factor).
+
+        Returns:
+            list or None: the resolved encoder list, or None if this item
+            has no pre-determined encoderList.
+        """
+        if self.encoderList is None:
+            return None
+        procEncoderList = []
+        for enc in self.encoderList:
+            if enc == "FixedPoint":
+                if self.factor is None:
+                    raise ValueError(f"Forced float data item {self.name} with encoder list {self.encoderList} must have a factor defined for 'FixedPoint' encoding ({self.factor})")
+                procEncoderList.append(("FixedPoint", self.factor))
+            else:
+                procEncoderList.append(enc)
+        return procEncoderList
+
+    def __repr__(self):
+        return "FloatEncodingConfig(name=%r, factor=%r, encoderList=%r)" % (
+            self.name,
+            self.factor,
+            self.encoderList,
+        )
+
+
+class BinaryCifEncodingConfig:
+    """Container for all BinaryCifWriter float-encoding configuration."""
+
+    # -----------------------------------------------------------------------
+    # Global float-encoding switches
+    # -----------------------------------------------------------------------
+
+    # True:  use the configured RunLength encoding chains for selected
+    #        high-volume float items.
+    # False: treat those items as general floats and use automatic factor
+    #        detection and general FixedPoint chain selection.
+    USE_RUN_LENGTH_FLOAT_HINTS = True
+
+    # True:  when no safe FixedPoint factor is found (general/undetected
+    #        items only) and a column contains values with 5 or more decimal
+    #        places, encode it as StringArrayMasked.
+    # False: those high-precision fallback columns use float ByteArray
+    #        instead.
+    # NOTE: If set to True, the 'testSerialize' test will need to be updated.
+    USE_STRING_FLOAT_FALLBACK = False
+    STRING_FALLBACK_MIN_DECIMAL_PLACES = 5
+
+    # True:  for general float items with a safe FixedPoint factor, compare all
+    #        four supported integer encoding chains and use the smallest output.
+    # False: use FixedPoint -> Delta -> RunLength -> IntegerPacking ->
+    #        ByteArray directly without comparing alternative chains.
+    COMPARE_ALL_FIXED_POINT_CHAINS = True
+
+    # Used only for items that are NOT in FORCED_FLOAT_ITEMS (general
+    # floats), or for a forced item whose factor is explicitly
+    # set to None (auto-detect), when scanning the column to find the
+    # smallest safe factor.
+    MAX_FIXED_POINT_DECIMAL_PLACES = 4
+    FIXED_POINT_TOLERANCE = 1.0e-6
+
+    # -----------------------------------------------------------------------
+    # Forced float data items
+    # -----------------------------------------------------------------------
+    #
+    # Keys are full mmCIF item names, i.e. "_category.attribute".
+    # Values are FloatEncodingConfig(factor, encoderList) instances. Every item
+    # here is assumed to be a float.
+    FORCED_FLOAT_ITEMS = _set_float_item_names({
+
+        # ---- Cartesian coordinates: factor 1000, FixedPoint -> Delta -> IntegerPacking -> ByteArray ----
+        # PDB / standard model coordinates
+        "_atom_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+
+        # PDBx/mmCIF chemical component coordinates
+        "_chem_comp_atom.model_Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_chem_comp_atom.model_Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_chem_comp_atom.model_Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_chem_comp_atom.pdbx_model_Cartn_x_ideal": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_chem_comp_atom.pdbx_model_Cartn_y_ideal": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_chem_comp_atom.pdbx_model_Cartn_z_ideal": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+
+        # PDBx/mmCIF phasing-site coordinates
+        "_phasing_MIR_der_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_phasing_MIR_der_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_phasing_MIR_der_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_phasing_MAD_set_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_phasing_MAD_set_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_phasing_MAD_set_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+
+        # PDBx/mmCIF solvent atom-site mapping coordinates
+        "_pdbx_solvent_atom_site_mapping.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_solvent_atom_site_mapping.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_solvent_atom_site_mapping.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+
+        # ModelCIF / CSM template coordinates
+        "_ma_template_coord.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ma_template_coord.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ma_template_coord.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+
+        # IHM coordinates
+        "_ihm_starting_model_coord.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_starting_model_coord.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_starting_model_coord.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_sphere_obj_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_sphere_obj_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_sphere_obj_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_gaussian_obj_site.mean_Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_gaussian_obj_site.mean_Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_gaussian_obj_site.mean_Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_pseudo_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_pseudo_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_pseudo_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+
+        # FLR / FPS coordinates
+        "_flr_FPS_mean_probe_position.mpp_xcoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_flr_FPS_mean_probe_position.mpp_ycoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_flr_FPS_mean_probe_position.mpp_zcoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_flr_FPS_MPP_atom_position.xcoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_flr_FPS_MPP_atom_position.ycoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_flr_FPS_MPP_atom_position.zcoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+
+        # ---- Anisotropic displacement U matrix: factor 10000, FixedPoint -> Delta -> IntegerPacking -> ByteArray ----
+        "_atom_site_anisotrop.U[1][1]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site_anisotrop.U[1][2]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site_anisotrop.U[1][3]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site_anisotrop.U[2][2]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site_anisotrop.U[2][3]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site_anisotrop.U[3][3]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+
+        # ---- IHM sphere object radius: factor 1000, no Delta/RunLength ----
+        "_ihm_sphere_obj_site.object_radius": FloatEncodingConfig(1000, ["FixedPoint", "IntegerPacking", "ByteArray"]),
+
+        # ---- High-volume float items: factor auto-detected from data, RunLength chain ----
+        "_atom_site.occupancy": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+        "_atom_site.B_iso_or_equiv": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+        "_ihm_sphere_obj_site.rmsf": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+        "_ihm_starting_model_coord.B_iso_or_equiv": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+    })
+
+    # -----------------------------------------------------------------------
+    # Accessors
+    # -----------------------------------------------------------------------
+
+    @classmethod
+    def get_float_item_config(cls, itemName):
+        """Return the FloatEncodingConfig for itemName, or None if it isn't a forced type.
+
+        Args:
+            itemName (str): full item name, e.g. "_atom_site.Cartn_x"
+
+        Returns:
+            FloatEncodingConfig or None
+        """
+        return cls.FORCED_FLOAT_ITEMS.get(itemName)
+
+    @classmethod
+    def get_float_encoder_list(cls, itemName):
+        """Return the resolved encoder list for itemName, if it is a forced type.
+
+        Any "FixedPoint" entry in the item's encoderList is replaced with the
+        tuple ("FixedPoint", factor), using that item's own factor.
+
+        Args:
+            itemName (str): full item name, e.g. "_atom_site.Cartn_x"
+
+        Returns:
+            list or None: the resolved encoder list, or None if itemName is
+            not in FORCED_FLOAT_ITEMS, or if it has no pre-determined
+            encoderList.
+        """
+        itemConfig = cls.get_float_item_config(itemName)
+        if itemConfig is None:
+            return None
+        return itemConfig.get_float_encoder_list()
+
+
+BCIF_CONFIG = BinaryCifEncodingConfig()


### PR DESCRIPTION
# Optimize BinaryCIF float encoding with FixedPoint chain selection

## Summary

This PR improves BinaryCIF serialization of floating-point columns in `mmcif/io/BinaryCifWriter.py`.

The production writer previously encoded float columns directly as `ByteArray`. This change adds BinaryCIF `FixedPoint` encoding followed by integer compression chains. It uses specific encoding rules for known high-volume structural fields and automatically selects the smallest supported chain for other float columns.

The final writer was tested on these 10 structures:

* **PDB:** `2BVK`, `4HHB`, `12GB`, `4BTS`, and `3J3Q`
* **IHM:** `9A01`, `9A25`, and `9A8K`
* **AlphaFold:** `AF_AFA0A017SEY2F1`
* **ModelCIF:** `MA_MABAKCEPC0001`

### File-size comparison

The BCIF file sizes for all 10 structures were added together for each writer:

* Production writer: **167,044,307 bytes**
* Final writer: **48,187,201 bytes**
* Total space saved: **118,857,106 bytes**
* Overall size reduction: **71.153%**

The size reduction was calculated as:

```text
(production total size - final total size)
÷ production total size
× 100
```

### Serialization-time comparison

Each structure was serialized five times with each writer. For each structure, the median time from the five measured runs was selected. The median times for all 10 structures were then added together:

Production writer: 45.756497 seconds
Final writer: 61.785365 seconds
Overall time increase: 35.031%

The time increase was calculated as:
```
(final total of the 10 median times - production total of the 10 median times)
÷ production total of the 10 median times
× 100
```
The change is intentionally limited to one production file. It does not change the decoder, public writer API, dictionary loading, BinaryCIF version metadata, or package dependencies.


## Motivation

BinaryCIF is column-oriented and supports chaining encoders such as `FixedPoint`, `Delta`, `RunLength`, `IntegerPacking`, and `ByteArray`. The existing py-mmcif writer encoded float columns directly as `ByteArray`. This is valid, but it does not take advantage of the additional compression available for coordinates and other structured numeric columns.

This implementation follows the BinaryCIF encoding approach used in Mol* and supported by the `ciftools-java` library:

1. convert eligible float values into scaled integers using `FixedPoint`;
2. apply integer encoders that match the data pattern in each column;
3. fall back to numeric float `ByteArray` encoding when `FixedPoint` cannot be used safely.

The goal is to produce substantially smaller BCIF files while preserving the intended numeric precision and ensuring that the files can still be correctly read by other BinaryCIF implementations, including Mol* and `ciftools-java`.

## Scope

- **Base branch:** `rcsb/py-mmcif:dev-bcif-staging`
- **Head branch:** `yusufm99/py-mmcif:dev-bcif-chain-encoding`
- **Commit:** `096e052ba56353c6b867cacb175824dc8a7174f4`
- **Files changed:** 1
- **Diff:** 400 additions, 20 deletions
- **Modified file:** `mmcif/io/BinaryCifWriter.py`

No benchmark scripts, generated BCIF files, logs, backup writers, or local paths are included in the commit.

## What changed and why

This section documents both the implementation and the reasoning behind each decision.

The implementation separates two kinds of behavior:

1. **Behavior derived directly from the BinaryCIF and Mol* model**, including FixedPoint metadata, factor detection through four decimal places, the four integer-chain candidates, factor-1,000 coordinate encoding, and JavaScript-compatible rounding.
2. **Project-specific decisions derived from the py-mmcif data and experiments**, including the expanded coordinate-item list, factor-10,000 anisotropic-U handling, the `_ihm_sphere_obj_site.object_radius` rule, the explicit RunLength hints, overflow fallback, feature switches, and the decision to keep StringArray fallback disabled.

The internal evidence paths below refer to the evidence package generated for repository commit:

```text
096e052ba56353c6b867cacb175824dc8a7174f4
```

### 1. Pass column identity into the float encoder

#### Problem

The production float path received the values and mask for a column, but it did not receive the category or attribute name.

Without that context, the writer could not apply a deliberate precision or encoding policy to known structural fields. Coordinates, anisotropic displacement values, sphere radii, repeated B-factor fields, and unrelated general-purpose float columns all reached the same direct float `ByteArray` path.

#### External basis

Mol* supports encoding-strategy hints that identify a field by category and column name and optionally specify its float precision:

- [Mol* `EncodingStrategyHint`](https://github.com/molstar/molstar/blob/master/src/mol-io/writer/cif.ts#L102-L116)
- [Mol* encoding-provider lookup by category and column](https://github.com/molstar/molstar/blob/master/src/mol-io/writer/cif.ts#L47-L69)


#### Change

The internal call path now forwards `catName` and `atName`:

```text
BinaryCifWriter.serialize()
→ __encodeColumnData()
→ BinaryCifEncoders.encodeWithMask()
→ floatArrayMaskedEncoder()
```

The float encoder normalizes those values into an item name of the form:

```text
_category.attribute
```

This allows it to select a specialized policy when one exists and the general float classifier otherwise.

The public interface remains unchanged:

```python
serialize(filePath, containerList)
```

No constructor argument or public method signature was added.

#### Validation

The final writer passed:

- the two existing targeted BinaryCIF writer tests;
- the full repository suite of 114 tests, with only the three existing dictionary-test skips;
- 37 CIF → BCIF → CIF comparisons with no structural, mask, value, or raw-type mismatches.

#### Result and decision

Column context is retained as an internal implementation detail because it enables precision and chain selection without changing the writer API or changing how dictionary types are assigned.

**Internal evidence:**

```text
01_final_source/BinaryCifWriter_final.py
02_python_tests/testBinaryCifWriter_final.log
02_python_tests/full_test_suite_final.log
03_round_trip/roundtrip_totals.txt
```

---

### 2. Add a typed FixedPoint encoder and track type changes through the chain

#### Problem

The production writer encoded dictionary-typed float columns directly as float `ByteArray` data.

That representation is valid, but it does not allow the writer to exploit the lower dynamic range and repeated patterns that become available after decimal float values are converted into scaled integers.

A second issue was type propagation. Once `FixedPoint` transforms floats into integers, all later encoders must treat the working array as integer data. Continuing to pass the original float type to `ByteArray` would produce incorrect encoding metadata and packing behavior.

#### External basis

BinaryCIF defines `FixedPoint` as a float-to-`Int32` transformation containing:

- `kind`;
- `factor`;
- original float `srcType`.

See:

- [BinaryCIF encoding specification](https://github.com/molstar/BinaryCIF/blob/master/encoding.md)
- [Mol* `FixedPoint` metadata definition](https://github.com/molstar/molstar/blob/master/src/mol-io/common/binary-cif/encoding.ts#L104-L109)

Mol* performs the conversion using `Math.round`:

- [Mol* float classifier and integer conversion](https://github.com/molstar/molstar/blob/master/src/mol-io/common/binary-cif/classifier.ts#L141-L180)

The Mol* source also contains a TODO requesting a better overflow check before values are committed to an `Int32Array`.

#### Change

A typed `fixedPointEncoderTyped()` implementation now:

1. accepts only `float_32` or `float_64` source data;
2. multiplies every value by the selected integer factor;
3. rounds using JavaScript `Math.round`-compatible behavior;
4. verifies that every result is in the signed 32-bit range;
5. returns a `TypedArray` with data type `integer_32`;
6. records the BinaryCIF `FixedPoint` metadata.

The rounding helper uses:

```python
math.floor(value + 0.5)
```

This reproduces the relevant JavaScript `Math.round` behavior, including its treatment of negative half values.

The generic chain executor now tracks the working data type. After `FixedPoint`, later `Delta`, `RunLength`, `IntegerPacking`, and `ByteArray` stages operate on integer data rather than on the original float type.

#### Safety behavior

FixedPoint is not used when:

- a value is `NaN`;
- a value is positive or negative infinity;
- scaling would exceed the signed `int32` range;
- a requested chain raises an encoding exception.

Those cases use the established numeric float `ByteArray` path.

#### Validation

The focused fallback test verified five direct cases:

```text
coordinate_nan               → ByteArray
coordinate_positive_infinity → ByteArray
coordinate_negative_infinity → ByteArray
coordinate_int32_overflow    → ByteArray
normal_coordinate            → FixedPoint, Delta, IntegerPacking, ByteArray
```

The 37-structure round-trip comparison then checked 143,178,047 values and reported:

```text
Structural mismatches: 0
Mask mismatches:       0
Value mismatches:      0
Raw type mismatches:   0
Maximum absolute error: 0
```

All 37 generated files also passed the independent Java encoding verifier.

#### Result and decision

Typed FixedPoint encoding is enabled by default. Explicit finite-value and signed-`int32` checks were retained because they make failure behavior deterministic and address a safety concern that the Mol* classifier itself identifies.

**Internal evidence:**

```text
01_final_source/BinaryCifWriter_final.py
02_python_tests/focused_float_fallback_test_final.log
03_round_trip/roundtrip_totals.txt
04_java_verifier/final_pr_encoding_verifier_summary.txt
```

---

### 3. Detect a safe FixedPoint factor for general float columns

#### Problem

A fixed factor cannot be safely applied to every float column.

Some columns contain integer-valued floats, some require one to four decimal places, and some require more precision than the FixedPoint policy supports. The writer therefore needed a bounded rule for determining when a general float column can be converted to integers without blindly applying a factor.

#### External basis

The Mol* float classifier:

- examines at most four decimal places;
- uses a tolerance of `1e-6`;
- returns to `ByteArray` when a safe conversion cannot be established.

See:

- [Mol* float classification](https://github.com/molstar/molstar/blob/master/src/mol-io/common/binary-cif/classifier.ts#L141-L180)

#### Change

For general float columns, the writer searches these factors in ascending order:

```text
1
10
100
1,000
10,000
```

For every value, it tests whether the scaled value lies within `1.0e-6` of an integer.

The greatest number of decimal places required by any value in the column determines the factor:

| Required precision | Factor |
|---:|---:|
| Integer-valued floats | `1` |
| One decimal place | `10` |
| Two decimal places | `100` |
| Three decimal places | `1,000` |
| Four decimal places | `10,000` |

The detector returns no factor when:

- any unmasked value is non-finite;
- any value requires more than four detectable decimal places;
- no tested factor satisfies the tolerance.

A separate signed-`int32` check is then performed on the fully scaled column before the selected encoding is accepted.

Known coordinate items are intentionally different: they retain the explicit factor-`1,000` coordinate policy rather than deriving their factor from the individual values in each file.

#### Validation

The final round-trip and interoperability tests validate the resulting factors across the complete 37-structure corpus.

The final evidence package does not contain a standalone unit-test table exercising factor `1`, `10`, `100`, `1,000`, and `10,000` individually. The factor order, tolerance, and bounded four-decimal behavior are directly visible in the final source, while the integration evidence verifies the resulting output across real PDB, IHM, AlphaFold, and ModelCIF data.

#### Result and decision

Automatic factor detection is used for general float columns and for the repeated-field hints whose precision is not fixed in advance.

The search remains bounded at four decimal places to match the adopted Mol* classification model and to prevent uncontrolled integer growth.

**Internal evidence:**

```text
01_final_source/BinaryCifWriter_final.py
03_round_trip/roundtrip_summary.tsv
04_java_verifier/final_pr_encoding_verifier.log
```

---

### 4. Compare four integer chains for general FixedPoint columns

#### Problem

After a float column is converted to integers, no single integer chain is best for every data pattern.

For example:

- direct IntegerPacking can be best for irregular low-range data;
- RunLength can help repeated values;
- Delta can help gradually changing values;
- Delta followed by RunLength can help repeated differences.

Always forcing one chain would improve some columns while making others larger.

#### External basis

Mol* considers the same four integer strategies:

1. `IntegerPacking`
2. `RunLength → IntegerPacking`
3. `Delta → IntegerPacking`
4. `Delta → RunLength → IntegerPacking`

See:

- [Mol* integer-chain classification](https://github.com/molstar/molstar/blob/master/src/mol-io/common/binary-cif/classifier.ts#L118-L138)
- [Mol* FixedPoint chain construction](https://github.com/molstar/molstar/blob/master/src/mol-io/common/binary-cif/classifier.ts#L163-L172)
- [Mol* encoding-strategy resolution](https://github.com/molstar/molstar/blob/master/src/mol-io/writer/cif.ts#L71-L98)

#### Change

When a safe factor is available, py-mmcif evaluates these candidates in this order:

```text
FixedPoint → IntegerPacking → ByteArray
FixedPoint → RunLength → IntegerPacking → ByteArray
FixedPoint → Delta → IntegerPacking → ByteArray
FixedPoint → Delta → RunLength → IntegerPacking → ByteArray
```

The candidate chains reuse py-mmcif’s existing Delta and RunLength encoders. These pre-existing encoders decline to transform columns with 40 or fewer values, and RunLength also declines when its value/count representation would contain more integers than the input. The threshold of 40 already exists in the current py-mmcif BinaryCifWriter script and was not introduced or independently selected by this change.


#### Validation

The controlled benchmark validates the complete final classifier against the production writer on ten structures under identical conditions.

Across the complete ten-structure set:

```text
Production total BCIF size: 167,044,307 bytes
Final total BCIF size:       48,187,201 bytes
Bytes saved:                118,857,106 bytes
Overall size reduction:          71.153%
```

The additional classification work increased serialization time:

```text
Production sum of medians: 45.756497 seconds 
Final sum of medians: 61.785365 seconds 
Overall time increase: 35.031%
```

These numbers measure the complete final implementation. They do not isolate the contribution of the four-chain classifier from the specialized hints.

#### Result and decision

The four-chain comparison was retained because it provides broad automatic coverage and produced a substantial aggregate size reduction, with the serialization-time increase documented as the principal tradeoff.

**Internal evidence:**

```text
08_final_benchmark/benchmark_runs.tsv
08_final_benchmark/benchmark_summary.tsv
08_final_benchmark/benchmark_aggregate.tsv
08_final_benchmark/benchmark_metadata.txt
```

---

### 5. Use factor 1,000 and a Delta-based chain for known coordinates

#### Problem

Coordinate columns are among the largest numeric columns in structural data. Encoding them directly as 32- or 64-bit floating-point byte arrays misses substantial compression.

Allowing each coordinate column to infer its own precision would also make the stored coordinate precision depend on the particular values present in the file rather than on one deliberate coordinate policy.

#### External basis

Mol* exposes a predefined factor-`1,000` FixedPoint coordinate-style chain:

```text
FixedPoint(1,000) → Delta → IntegerPacking
```

See:

- [Mol* `fixedPoint3`](https://github.com/molstar/molstar/blob/master/src/mol-io/writer/cif.ts#L36-L41)

#### Change

Known Cartesian coordinate items request:

```text
FixedPoint(1,000)
→ Delta
→ IntegerPacking
→ ByteArray
```

#### Expanded coordinate coverage

The project expanded the coordinate hint beyond `_atom_site` to known coordinate-bearing items from:

- standard PDBx/mmCIF atom coordinates;
- chemical-component model and ideal coordinates;
- phasing-site categories;
- solvent atom-site mapping;
- ModelCIF template coordinates;
- IHM starting-model coordinates;
- IHM sphere, Gaussian, ensemble, and pseudo-site coordinates;
- FLR/FPS mean-probe and atom-position coordinates.

This expanded item set is a py-mmcif project decision. It should not be presented as an exact copy of the Mol* field list.

#### Coordinate-factor experiment

Factors `1,000`, `100,000`, and `1,000,000` were evaluated during development.

The higher factors:

- produced larger scaled integers;
- reduced IntegerPacking efficiency;
- increased BCIF size;
- increased serialization time;
- did not provide a meaningful practical accuracy benefit that justified those costs in the decoded comparisons.

#### Validation

The final factor-`1,000` configuration passed:

- all 37 Python round-trip validations with no value mismatches;
- all 37 Java verifier checks;
- Mol* parsing and rendering for conventional PDB and coordinate-heavy IHM examples.

The final benchmark showed particularly large reductions for coordinate-heavy files, but those file-level results reflect the complete implementation and should not be attributed only to the coordinate rule.

#### Result and decision

Factor `1,000` was retained because it:

- aligns with the Mol* reference approach;
- compresses more effectively than the larger tested factors;
- avoids their additional serialization cost;
- passed the complete interoperability and round-trip validation set.

**Development evidence:**

```text
coordinate_factor_analysis_upload.zip
```

**Final evidence:**

```text
03_round_trip/roundtrip_totals.txt
04_java_verifier/final_pr_encoding_verifier_summary.txt
05_molstar/molstar_4HHB.png
05_molstar/molstar_9A8K.png
08_final_benchmark/benchmark_summary.tsv
```

---

### 6. Add project-specific hints for anisotropic U values, IHM sphere radii, and repeated fields

The general four-chain classifier provides broad coverage, but development audits identified several high-volume fields with stable precision requirements or predictable value patterns.

These specialized decisions were developed from the project data. They are not claimed to be exact field rules copied from Mol*.

#### 6.1 Six anisotropic-U fields

##### Problem

The six independent `_atom_site_anisotrop.U[i][j]` values commonly require four-decimal handling rather than the three-decimal coordinate policy.

Encoding them as direct floats leaves compression available, while using factor `1,000` could remove a decimal place that is intentionally represented in these columns.

##### Change

The following fields request factor `10,000`:

```text
_atom_site_anisotrop.U[1][1]
_atom_site_anisotrop.U[1][2]
_atom_site_anisotrop.U[1][3]
_atom_site_anisotrop.U[2][2]
_atom_site_anisotrop.U[2][3]
_atom_site_anisotrop.U[3][3]
```

Their requested chain is:

```text
FixedPoint(10,000)
→ Delta
→ IntegerPacking
→ ByteArray
```

##### Validation

`4BTS`, which contains anisotropic-U data, passed:

- the Python round-trip comparison;
- the Java encoding verifier;
- Mol* parsing and rendering.

##### Result and decision

Factor `10,000` was retained to preserve four-decimal U-matrix handling while allowing the values to use the integer compression pipeline.

**Internal evidence:**

```text
03_round_trip/roundtrip_summary.tsv
04_java_verifier/final_pr_encoding_verifier.log
05_molstar/molstar_4BTS.png
```

#### 6.2 `_ihm_sphere_obj_site.object_radius`

##### Problem

IHM sphere radii are numeric, often high-volume, and suitable for FixedPoint conversion, but their ordering does not necessarily make Delta useful and their values do not necessarily form long repeated runs.

##### Change

`_ihm_sphere_obj_site.object_radius` requests:

```text
FixedPoint(1,000)
→ IntegerPacking
→ ByteArray
```

No fixed Delta or RunLength stage is requested.

##### Validation

The IHM validation corpus, including `9A8K` and `9A25`, passed the Python and Java checks. Representative IHM output also parsed and rendered in Mol*.

##### Result and decision

The direct FixedPoint-plus-IntegerPacking rule was retained as the explicit policy for this known IHM field.

**Internal evidence:**

```text
03_round_trip/roundtrip_summary.tsv
04_java_verifier/final_pr_encoding_verifier.log
05_molstar/molstar_9A8K.png
```

#### 6.3 Repeated high-volume float fields

##### Problem

Several large float columns frequently contain long repeated runs. Running the full four-candidate classifier on each known case adds classification work even when the expected useful pattern is already known.

##### Change

These four fields receive an automatically detected factor followed by a requested RunLength chain:

```text
_atom_site.occupancy
_atom_site.B_iso_or_equiv
_ihm_sphere_obj_site.rmsf
_ihm_starting_model_coord.B_iso_or_equiv
```

The requested chain is:

```text
FixedPoint(automatically detected factor)
→ RunLength
→ IntegerPacking
→ ByteArray
```

The factor is not hard-coded. It is determined from the actual values using the same bounded four-decimal factor detector as other general floats.

The existing RunLength guard prevents this hint from expanding the integer stream. When RunLength would produce more integers than the original array, that stage is omitted.

##### Validation

The final PDB and IHM corpus passed all round-trip and Java compatibility checks.

The aggregate benchmark validates the complete final configuration. It does not prove a separate percentage contribution for each of the four RunLength-hinted fields.

##### Result and decision

The hints were retained because they reflect observed repeated-value patterns, avoid running all four candidate chains for established high-volume cases, and retain the existing guard against harmful RunLength expansion.

**Internal evidence:**

```text
01_final_source/BinaryCifWriter_final.py
03_round_trip/roundtrip_summary.tsv
04_java_verifier/final_pr_encoding_verifier.log
08_final_benchmark/benchmark_summary.tsv
```

---

### 7. Preserve existing mask behavior through the new float chains

#### Problem

Some CIF float columns contain special missing-value markers:

* `.` means the value was not specified;
* `?` means the value is unknown.

These markers are not numbers, so they cannot be passed directly through numeric encoders such as `FixedPoint`, `Delta`, `RunLength`, or `IntegerPacking`.

#### External basis

BinaryCIF stores missing-value information in a separate mask:

```text
0 = real value is present
1 = . not specified
2 = ? unknown
```

See:

* [BinaryCIF mask definition in Mol*](https://github.com/molstar/molstar/blob/master/src/mol-io/common/binary-cif/encoding.ts#L38-L56)

#### Change

The existing py-mmcif mask behavior was preserved when the new float-encoding chains were added.

For example, this logical column:

```text
1.25, ., 1.50, ?, 1.75
```

is handled as two separate arrays.

The numeric data stream becomes:

```text
1.25, 0.0, 1.50, 0.0, 1.75
```

The mask becomes:

```text
0, 1, 0, 2, 0
```

The temporary `0.0` values allow the numeric data to pass safely through the new compression chain.

The mask keeps the original meaning at each position:

* data `0.0` with mask `1` is restored as `.`;
* data `0.0` with mask `2` is restored as `?`;
* data `0.0` with mask `0` remains a real numeric zero.

When a mask is needed, it is:

* stored as `unsigned_integer_8`;
* encoded separately using `RunLength → ByteArray`;
* written in the BinaryCIF column’s separate `mask` object.

When every value is present, no mask object is written.

#### Validation

The 37-structure round-trip validation reported:

```text
Mask mismatches: 0
```

The same BCIF files also passed the Java encoding verifier, and representative files loaded successfully in Mol*.

#### Result and decision

The mask system itself was not redesigned by this change.

The existing separate-mask behavior was kept so that missing and unknown values remain correct while the numeric value stream can safely use the new `FixedPoint` and integer-encoding chains.

**Internal evidence:**

```text
03_round_trip/roundtrip_summary.tsv
03_round_trip/roundtrip_totals.txt
04_java_verifier/final_pr_encoding_verifier_summary.txt
```

---

### 8. Keep unsafe and high-precision fallback columns numeric

#### Problem

Some float columns cannot safely use the bounded FixedPoint path because they:

- require more than four detected decimal places;
- overflow signed `int32` after scaling;

An experimental alternative converted certain high-precision values to `StringArrayMasked`.

Although BinaryCIF supports `StringArray`, the experimental fallback encoded dictionary-defined float columns as strings. After decoding, downstream dictionary-aware code could therefore receive string values where numeric float values were expected, creating type mismatches and possible conversion or writing errors. Keeping the fallback disabled preserves the expected numeric representation.

#### Change

The final default is:

```python
USE_STRING_FLOAT_FALLBACK = False
```

Therefore, unsupported general float columns remain numeric and use:

```text
float ByteArray
```

The byte width continues to follow the writer’s existing `useFloat64` setting.

This fallback also applies to unsafe specialized paths. A coordinate, anisotropic-U, sphere-radius, or repeated-field hint does not force FixedPoint when its values are non-finite or do not fit signed `int32`.

#### Validation

The focused final test confirmed that:

- `NaN` uses `ByteArray`;
- positive infinity uses `ByteArray`;
- negative infinity uses `ByteArray`;
- signed-`int32` overflow uses `ByteArray`;
- an ordinary coordinate still uses the intended FixedPoint chain.

The 37-structure round-trip audit found no raw-type mismatches, and all outputs passed the Java verifier.

#### Result and decision

The StringArray fallback remains in the implementation for possible future evaluation, but it is disabled in this PR.

The final writer keeps dictionary-defined float columns numeric because that is the lower-risk choice for type semantics and interoperability.

**Internal evidence:**

```text
02_python_tests/focused_float_fallback_test_final.log
03_round_trip/roundtrip_raw_type_audit.tsv
03_round_trip/roundtrip_totals.txt
04_java_verifier/final_pr_encoding_verifier_summary.txt
```

---

### 9. Retain internal feature switches used during development

#### Problem

The implementation needed a controlled way to isolate the general FixedPoint path and each specialized rule during development.

Without separate switches, changing one rule at a time would require repeatedly editing the encoder logic and would make comparisons more error-prone.

#### Change

`BinaryCifEncoders` contains these internal class-level switches:

| Switch | Final default | Behavior when `True` | Behavior when `False` |
|---|---:|---|---|
| `USE_FIXED_POINT_FLOAT_ENCODING` | `True` | Enables the new FixedPoint path and all enabled specialized rules | Restores direct float `ByteArray` behavior for all float columns |
| `USE_COORDINATE_CHAIN` | `True` | Coordinates request factor `1,000` with `Delta → IntegerPacking` | Coordinates retain factor `1,000` but use general four-chain selection |
| `USE_ANISOTROP_U_CHAIN` | `True` | Six U fields request factor `10,000` with `Delta → IntegerPacking` | U fields use general factor detection and four-chain selection |
| `USE_OBJECT_RADIUS_CHAIN` | `True` | Sphere radius requests factor `1,000` with `IntegerPacking` | Sphere radius uses the general float path |
| `USE_RUN_LENGTH_FLOAT_HINTS` | `True` | Four repeated fields request the RunLength chain | Those fields use general four-chain selection |
| `USE_STRING_FLOAT_FALLBACK` | `False` | Eligible unsupported floats may use `StringArrayMasked` | Unsupported floats remain numeric `ByteArray` data |

Except for the master FixedPoint switch, disabling one specialized switch does not force that field directly to `ByteArray`. It sends the field through the general FixedPoint logic instead.

#### Validation scope

The final validation package tests the production defaults shown above.

#### Result and decision

The switches remain internal class attributes because they make the individual policies reviewable and allow for quick troubleshooting and experimenting.

**Internal evidence:**

```text
01_final_source/BinaryCifWriter_final.py
```

---

## Before-and-after summary

| Column or condition | Production behavior | Final behavior |
|---|---|---|
| Known Cartesian coordinates | Direct float `ByteArray` | Factor `1,000` with requested `Delta → IntegerPacking → ByteArray` |
| Six anisotropic-U fields | Direct float `ByteArray` | Factor `10,000` with requested `Delta → IntegerPacking → ByteArray` |
| `_ihm_sphere_obj_site.object_radius` | Direct float `ByteArray` | Factor `1,000` with `IntegerPacking → ByteArray` |
| Four repeated high-volume fields | Direct float `ByteArray` | Automatically detected factor with requested `RunLength → IntegerPacking → ByteArray` |
| Other safe floats requiring up to four decimal places | Direct float `ByteArray` | Smallest payload from four FixedPoint integer-chain candidates |
| General floats requiring more than four detected decimal places | Float `ByteArray` | Float `ByteArray` |
| Non-finite values | Float `ByteArray` | Float `ByteArray` |
| Unsafe signed-`int32` scaling | Float `ByteArray` | Float `ByteArray` |
| Missing and unknown values | Separate mask | Separate mask; unchanged |
| Dictionary-typed integer columns | Existing integer path | Unchanged |
| Dictionary-typed string columns | Existing StringArray path | Unchanged |


The final result is a deliberate size-versus-write-time tradeoff:

```text
71.153% smaller total BCIF output
35.031% slower aggregate median serialization time
```




## Controlled benchmark

### Methodology

- **Python:** 3.13.0
- **Platform:** WSL2 Linux, x86-64
- **Writer setting:** `useFloat64=True`
- **String fallback:** disabled
- **Structures:** 10 spanning PDB, IHM, AlphaFold, and ModelCIF
- **Warm-up:** 1 run per structure per writer
- **Measured repetitions:** 5 per structure per writer
- **Primary timing statistic:** median
- **Timed operation:** `BinaryCifWriter.serialize()`, including output-file writing
- **Excluded from timing:** input CIF parsing and dictionary loading
- **Bias reduction:** baseline/final execution order alternated between measured runs


### Aggregate result

| Metric | Production writer | Final writer | Change |
|---|---:|---:|---:|
| Total BCIF size | 167,044,307 bytes | 48,187,201 bytes | **71.153% smaller** |
| Sum of per-structure median serialization times | 45.756497 s | 61.785365 s | **35.031% slower** |

Additional aggregate statistics:

- total bytes saved: **118,857,106**;
- median per-structure size reduction: **62.001%**;
- median per-structure serialization change: **39.381% slower**.

### Per-structure results

| Structure | Type / coverage | Production BCIF | Final BCIF | Size change | Production median | Final median | Time change |
|---|---|---:|---:|---:|---:|---:|---:|
| `2BVK` | PDB, small | 88,586 | 86,997 | **1.794% smaller** | 0.009673 s | 0.011364 s | **17.488% slower** |
| `4HHB` | PDB, small/medium | 530,943 | 312,728 | **41.100% smaller** | 0.088222 s | 0.136012 s | **54.170% slower** |
| `12GB` | PDB, medium | 4,273,820 | 1,289,137 | **69.836% smaller** | 0.929353 s | 1.303115 s | **40.218% slower** |
| `4BTS` | PDB, large, anisotropic U | 19,845,300 | 6,442,338 | **67.537% smaller** | 4.200834 s | 6.457648 s | **53.723% slower** |
| `3J3Q` | PDB, very large | 113,322,354 | 29,156,671 | **74.271% smaller** | 28.511336 s | 39.500949 s | **38.545% slower** |
| `9A01` | IHM, small | 1,536,585 | 486,643 | **68.330% smaller** | 0.260257 s | 0.366516 s | **40.828% slower** |
| `9A25` | IHM, large | 9,965,128 | 6,245,536 | **37.326% smaller** | 9.586133 s | 10.056246 s | **4.904% slower** |
| `9A8K` | IHM, coordinate-heavy | 16,699,656 | 3,806,185 | **77.208% smaller** | 2.009673 s | 3.740031 s | **86.101% slower** |
| `AF_AFA0A017SEY2F1` | AlphaFold/CSM | 196,016 | 105,881 | **45.983% smaller** | 0.034709 s | 0.046315 s | **33.439% slower** |
| `MA_MABAKCEPC0001` | ModelCIF/CSM | 585,919 | 255,085 | **56.464% smaller** | 0.126307 s | 0.167168 s | **32.350% slower** |


Raw benchmark artifacts generated during validation:

- `benchmark_runs.tsv`;
- `benchmark_summary.tsv`;
- `benchmark_aggregate.tsv`;
- `benchmark_metadata.txt`.

### Interpretation

The optimization strongly favors reduced output size over write speed:

- large and coordinate-heavy structures show the largest compression gains;
- 9A8K was 77.208% smaller, while serialization time increased by 86.101%;
- 3J3Q saved more than 84 million bytes and was 74.271% smaller;
- 9A25 achieved a 37.326% size reduction with only a 4.904% timing increase;
- very small files such as 2BVK have little redundant float data, so the additional classification work provides limited size benefit.

The aggregate result should be used for the overall tradeoff. A simple arithmetic average of individual percentages can overstate the effect of small files and is not used as the primary result.