### PR TITLE
Bcif config consolidation

### DIFF
--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -13,9 +13,8 @@
 #     If supplied, it is used only as a fallback for all-sentinel/empty columns.
 #   - DataCategoryTyped pre-casting is skipped when dictionaryApi is None.
 #   - __encodeColumnData() casts raw string values to int/float before encoding.
-#   - __getAttributeType() uses classify_column() as primary type resolver.
-#   - _FORCE_STRING_ATTRS overrides auto-detection for char-typed attributes
-#     that look numeric (e.g. _audit_conform.dict_version = "5.281").
+#   - __getAttributeType() uses centralized item policy before
+#     bcif_type_detector.classify_column().
 #
 #   15-Jul-2026 ym
 #   - Added FixedPoint float encoding with IntegerPacking, RunLength, and Delta
@@ -221,8 +220,8 @@ class BinaryCifWriter(object):
         """Resolve a column type without changing either legacy path.
 
         Dictionary mode reproduces the original BinaryCifWriter behavior.
-        Auto-detect mode applies forced types first, then scans the values, and
-        optionally uses dictionaryApi only for empty/all-sentinel columns.
+        Auto-detect mode applies configured item types first, then scans the
+        values when no item policy exists.
         """
         if not self.__useAutoDetect:
             cifDataType = self.__dApi.getTypeCode(catName, atName)
@@ -787,8 +786,8 @@ class BinaryCifEncoders(object):
             itemName = canonical_item_name(catName, atName)
         itemConfig = BCIF_CONFIG.get_float_item_config(itemName)
 
-        # Forced float items with a fixed factor always use their configured
-        # factor and encoder chain.
+        # Configured float items with a fixed factor use their configured
+        # factor and post-FixedPoint integer chain.
         if itemConfig is not None and itemConfig.factor is not None:
             factor = itemConfig.factor
             encoderList = (("FixedPoint", factor),) + itemConfig.integer_chain

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -36,7 +36,17 @@ import warnings
 from mmcif.api.DataCategoryTyped import DataCategoryTyped, DataCategoryHints
 from mmcif.api.PdbxContainers import CifName
 from mmcif.io.BinaryCifReader import BinaryCifDecoders
-from mmcif.io.config import BCIF_CONFIG, canonical_item_name, get_forced_type
+from mmcif.io.config import (
+    BCIF_CONFIG,
+    DEFAULT_FIXED_POINT_INTEGER_CHAIN,
+    DEFAULT_INTEGER_CHAIN,
+    FIXED_POINT_CANDIDATE_INTEGER_CHAINS,
+    FLOAT_BYTE_ARRAY_FALLBACK_CHAIN,
+    MASK_ENCODING_CHAIN,
+    MISSING_VALUE_TOKENS,
+    canonical_item_name,
+    get_forced_type,
+)
 
 from mmcif.io.bcif_type_detector import classify_column
 
@@ -159,7 +169,6 @@ class BinaryCifWriter(object):
         colMaskDict = None  # Use None when no mask and not {} - per Mol* implementation
         enc = BinaryCifEncoders(defaultStringEncoding=self.__defaultStringEncoding, storeStringsAsBytes=self.__storeStringsAsBytes, useFloat64=self.__useFloat64)
         #
-        maskEncoderList = ["RunLength", "ByteArray"]
         typeEncoderD = {"string": "StringArrayMasked", "integer": "IntArrayMasked", "float": "FloatArrayMasked"}
         colMaskList = enc.getMask(colDataList)
 
@@ -169,16 +178,15 @@ class BinaryCifWriter(object):
         # Cast here using the dataType already determined by __getAttributeType.
         # Sentinel values (".", "?", None) are left untouched so getMask()
         # results remain valid.
-        _SENTINELS = {".", "?"}
         if self.__useAutoDetect and dataType == "integer":
             colDataList = [
-                v if (v is None or v in _SENTINELS)
+                v if (v is None or v in MISSING_VALUE_TOKENS)
                 else (v if isinstance(v, int) else int(v))
                 for v in colDataList
             ]
         elif self.__useAutoDetect and dataType == "float":
             colDataList = [
-                v if (v is None or v in _SENTINELS)
+                v if (v is None or v in MISSING_VALUE_TOKENS)
                 else (v if isinstance(v, float) else float(v))
                 for v in colDataList
             ]
@@ -189,7 +197,7 @@ class BinaryCifWriter(object):
         if colMaskList:
             # Mol* indicates that masks should be encoded as if uint_8
             colMaskListTyped = TypedArray(colMaskList, "unsigned_integer_8")
-            maskEncoded, maskEncodingDictL = enc.encode(colMaskListTyped, maskEncoderList, "integer")
+            maskEncoded, maskEncodingDictL = enc.encode(colMaskListTyped, MASK_ENCODING_CHAIN, "integer")
             colMaskDict = {self.__toBytes("data"): maskEncoded.data, self.__toBytes("encoding"): maskEncodingDictL}
         return colMaskDict, colDataEncoded, colDataEncodingDictL
 
@@ -292,7 +300,6 @@ class BinaryCifEncoders(object):
             storeStringsAsBytes (bool, optional): strings are stored as bytes. Defaults to True.
             useFloat64 (bool, optional): store floats in 64 bit precision. Defaults to True.
         """
-        self.__unknown = [".", "?"]
         self.__defaultStringEncoding = defaultStringEncoding
         self.__storeStringsAsBytes = storeStringsAsBytes
         self.__useFloat64 = useFloat64
@@ -605,7 +612,7 @@ class BinaryCifEncoders(object):
                 continue
 
             valueString = str(val).strip()
-            if valueString in self.__unknown:
+            if valueString in MISSING_VALUE_TOKENS:
                 continue
 
             if "e" in valueString.lower():
@@ -659,10 +666,8 @@ class BinaryCifEncoders(object):
     def __encodeBestFixedPointChain(self, colDataList, factor):
         """Try the four FixedPoint integer chains and return the smallest output."""
         candidateEncoderLists = [
-            [("FixedPoint", factor), "IntegerPacking", "ByteArray"],
-            [("FixedPoint", factor), "RunLength", "IntegerPacking", "ByteArray"],
-            [("FixedPoint", factor), "Delta", "IntegerPacking", "ByteArray"],
-            [("FixedPoint", factor), "Delta", "RunLength", "IntegerPacking", "ByteArray"],
+            (("FixedPoint", factor),) + integerChain
+            for integerChain in FIXED_POINT_CANDIDATE_INTEGER_CHAINS
         ]
 
         bestSize = None
@@ -696,7 +701,7 @@ class BinaryCifEncoders(object):
         Returns:
             (list, list): encoded data column, list of encoding instructions
         """
-        integerEncoderList = ["Delta", "RunLength", "IntegerPacking", "ByteArray"]
+        integerEncoderList = DEFAULT_INTEGER_CHAIN
         uniqStringIndex = {}  # keys are substrings, values indices
         uniqStringList = []
         indexList = []
@@ -738,7 +743,7 @@ class BinaryCifEncoders(object):
         Returns:
             (list, list): encoded data column, list of encoding instructions
         """
-        integerEncoderList = ["Delta", "RunLength", "IntegerPacking", "ByteArray"]
+        integerEncoderList = DEFAULT_INTEGER_CHAIN
 
         if colMaskList:
             # Mol* and BinaryCif specification https://github.com/molstar/BinaryCIF/blob/master/encoding.md
@@ -756,19 +761,19 @@ class BinaryCifEncoders(object):
             numericValues = [float(v) for v in colDataList]
 
             if not all(math.isfinite(v) for v in numericValues):
-                return self.encode(colDataList, ["ByteArray"], "float")
+                return self.encode(colDataList, FLOAT_BYTE_ARRAY_FALLBACK_CHAIN, "float")
 
             fixedPointValues = [
                 self.__roundLikeMolStar(v * factor)
                 for v in numericValues
             ]
             if not self.__fitsInt32(fixedPointValues):
-                return self.encode(colDataList, ["ByteArray"], "float")
+                return self.encode(colDataList, FLOAT_BYTE_ARRAY_FALLBACK_CHAIN, "float")
 
             return self.encode(colDataList, encoderList, "float")
         except Exception as e:
             logger.debug("Falling back from the fixed float chain for %s: %s", itemName, str(e))
-            return self.encode(colDataList, ["ByteArray"], "float")
+            return self.encode(colDataList, FLOAT_BYTE_ARRAY_FALLBACK_CHAIN, "float")
 
     def floatArrayMaskedEncoder(self, colDataList, colMaskList, catName=None, atName=None, itemName=None):
         """Encode a float column, preserving its incompleteness mask."""
@@ -777,7 +782,7 @@ class BinaryCifEncoders(object):
         else:
             maskedColDataList = colDataList
 
-        fallbackEncoderList = ["ByteArray"]
+        fallbackEncoderList = FLOAT_BYTE_ARRAY_FALLBACK_CHAIN
         if itemName is None:
             itemName = canonical_item_name(catName, atName)
         itemConfig = BCIF_CONFIG.get_float_item_config(itemName)
@@ -786,7 +791,7 @@ class BinaryCifEncoders(object):
         # factor and encoder chain.
         if itemConfig is not None and itemConfig.factor is not None:
             factor = itemConfig.factor
-            encoderList = BCIF_CONFIG.get_float_encoder_list(itemName)
+            encoderList = (("FixedPoint", factor),) + itemConfig.integer_chain
             return self.__encodeFixedPointChainOrFallback(
                 maskedColDataList,
                 factor,
@@ -805,10 +810,7 @@ class BinaryCifEncoders(object):
                     return self.__encodeFloatStringFallback(colDataList, colMaskList)
                 return self.encode(maskedColDataList, fallbackEncoderList, "float")
 
-            encoderList = [
-                ("FixedPoint", factor),
-                *itemConfig.encoderList,
-            ]
+            encoderList = (("FixedPoint", factor),) + itemConfig.integer_chain
             return self.__encodeFixedPointChainOrFallback(
                 maskedColDataList,
                 factor,
@@ -836,13 +838,7 @@ class BinaryCifEncoders(object):
                 return self.encode(maskedColDataList, fallbackEncoderList, "float")
             return encodedColDataList, encodingDictL
 
-        encoderList = [
-            ("FixedPoint", factor),
-            "Delta",
-            "RunLength",
-            "IntegerPacking",
-            "ByteArray",
-        ]
+        encoderList = (("FixedPoint", factor),) + DEFAULT_FIXED_POINT_INTEGER_CHAIN
         return self.__encodeFixedPointChainOrFallback(
             maskedColDataList,
             factor,
@@ -862,7 +858,7 @@ class BinaryCifEncoders(object):
         """
         mask = None
         for ii, colVal in enumerate(colDataList):
-            if colVal is not None and colVal not in self.__unknown:
+            if colVal is not None and colVal not in MISSING_VALUE_TOKENS:
                 continue
             if not mask:
                 mask = [0] * len(colDataList)

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -43,7 +43,6 @@ from mmcif.io.config import (
     FLOAT_BYTE_ARRAY_FALLBACK_CHAIN,
     MASK_ENCODING_CHAIN,
     MISSING_VALUE_TOKENS,
-    canonical_item_name,
     get_forced_type,
 )
 
@@ -134,12 +133,12 @@ class BinaryCifWriter(object):
                     cols = []
                     for ii, atName in enumerate(cObj.getAttributeList()):
                         colDataList = cObj.getColumn(ii)
-                        itemName = canonical_item_name(catName, atName)
-                        dataType = self.__getAttributeType(catName, atName, itemName, colDataList) if not self.__useStringTypes else "string"
+                        dataType = self.__getAttributeType(catName, atName, colDataList) if not self.__useStringTypes else "string"
 
-                        logger.debug("itemName %r dataType %r", itemName, dataType)
+                        logger.debug("catName %r atName %r dataType %r", catName, atName, dataType)
+                        # Pass category/item names so float columns can use coordinate-specific hints
                         colMaskDict, encodedColDataList, encodingDictL = self.__encodeColumnData(
-                            colDataList, dataType, itemName
+                            colDataList, dataType, catName, atName
                         )
                         cols.append(
                             {
@@ -163,8 +162,8 @@ class BinaryCifWriter(object):
             logger.exception("Failing with %s", str(e))
         return False
 
-    # Accept the canonical item name so encoding policy is resolved only once.
-    def __encodeColumnData(self, colDataList, dataType, itemName=""):
+    # Accept category/item names so encoder selection can use column-specific hints
+    def __encodeColumnData(self, colDataList, dataType, catName=None, atName=None):
         colMaskDict = None  # Use None when no mask and not {} - per Mol* implementation
         enc = BinaryCifEncoders(defaultStringEncoding=self.__defaultStringEncoding, storeStringsAsBytes=self.__storeStringsAsBytes, useFloat64=self.__useFloat64)
         #
@@ -192,7 +191,7 @@ class BinaryCifWriter(object):
 
         dataEncType = typeEncoderD[dataType]
         # Forward category/item names to the masked encoder
-        colDataEncoded, colDataEncodingDictL = enc.encodeWithMask(colDataList, colMaskList, dataEncType, itemName=itemName)
+        colDataEncoded, colDataEncodingDictL = enc.encodeWithMask(colDataList, colMaskList, dataEncType, catName=catName, atName=atName)
         if colMaskList:
             # Mol* indicates that masks should be encoded as if uint_8
             colMaskListTyped = TypedArray(colMaskList, "unsigned_integer_8")
@@ -216,12 +215,12 @@ class BinaryCifWriter(object):
         return strVal
 
 
-    def __getAttributeType(self, catName, atName, itemName, colDataList):
+    def __getAttributeType(self, catName, atName, colDataList):
         """Resolve a column type without changing either legacy path.
 
         Dictionary mode reproduces the original BinaryCifWriter behavior.
-        Auto-detect mode applies configured item types first, then scans the
-        values when no item policy exists.
+        Auto-detect mode applies forced types first, then scans the values, and
+        optionally uses dictionaryApi only for empty/all-sentinel columns.
         """
         if not self.__useAutoDetect:
             cifDataType = self.__dApi.getTypeCode(catName, atName)
@@ -245,7 +244,7 @@ class BinaryCifWriter(object):
                     dataType = "integer"
 
         else:
-            forcedType = get_forced_type(itemName)
+            forcedType = get_forced_type(CifName().itemName(catName, atName))
             if forcedType is not None:
                 logger.debug(
                     "Forced type override applied for %s.%s -> %s",
@@ -360,8 +359,8 @@ class BinaryCifEncoders(object):
             return colDataList.data, encodingDictL
         return colDataList, encodingDictL
 
-    # Accept a canonical item name while retaining category/item compatibility.
-    def encodeWithMask(self, colDataList, colMaskList, encodingType, catName=None, atName=None, itemName=None):
+    # Accept category/item names for float-column encoding decisions
+    def encodeWithMask(self, colDataList, colMaskList, encodingType, catName=None, atName=None):
         """Encode the data using the input mask and encoding type returning encoded data and encoding instructions.
 
         Args:
@@ -369,10 +368,10 @@ class BinaryCifEncoders(object):
             colMaskList (list): incompleteness mask for the input data column
             encodingType (string): encoding type to apply
                 (StringArrayMasked, IntArrayMasked, FloatArrayMasked)
-            catName (str, optional): category name retained for compatibility.
-            atName (str, optional): attribute name retained for compatibility.
-            itemName (str, optional): canonical item name used for configured
-                float encoding decisions.
+            catName (str, optional): category name used for float-column
+                encoding decisions. Defaults to None.
+            atName (str, optional): attribute name used for float-column
+                encoding decisions. Defaults to None.
 
         Returns:
             (list, list ): encoded data column, list of encoding instructions
@@ -383,10 +382,14 @@ class BinaryCifEncoders(object):
             encodedColDataList, encodingDictL = self.stringArrayMaskedEncoder(colDataList, colMaskList)
         elif encodingType == "IntArrayMasked":
             encodedColDataList, encodingDictL = self.intArrayMaskedEncoder(colDataList, colMaskList)
+        # Pass category/item names only to the float encoder
         elif encodingType == "FloatArrayMasked":
-            if itemName is None:
-                itemName = canonical_item_name(catName, atName)
-            encodedColDataList, encodingDictL = self.floatArrayMaskedEncoder(colDataList, colMaskList, itemName=itemName)
+            encodedColDataList, encodingDictL = self.floatArrayMaskedEncoder(
+                colDataList,
+                colMaskList,
+                catName=catName,
+                atName=atName,
+            )
         else:
             logger.info("unsupported masked encoding %r", encodingType)
         return encodedColDataList, encodingDictL
@@ -604,6 +607,16 @@ class BinaryCifEncoders(object):
         """
         return all(-2147483648 <= int(v) <= 2147483647 for v in data)
 
+    def __getItemName(self, catName, atName):
+        """Return normalized _category.attribute item name."""
+        if catName is None or atName is None:
+            return ""
+
+        if catName.startswith("_"):
+            return "%s.%s" % (catName, atName)
+        else:
+            return "_%s.%s" % (catName, atName)
+
     def __shouldUseStringFallbackForFloat(self, colDataList):
         """Return True when the column requires high-precision float fallback."""
         for val in colDataList:
@@ -774,7 +787,7 @@ class BinaryCifEncoders(object):
             logger.debug("Falling back from the fixed float chain for %s: %s", itemName, str(e))
             return self.encode(colDataList, FLOAT_BYTE_ARRAY_FALLBACK_CHAIN, "float")
 
-    def floatArrayMaskedEncoder(self, colDataList, colMaskList, catName=None, atName=None, itemName=None):
+    def floatArrayMaskedEncoder(self, colDataList, colMaskList, catName=None, atName=None):
         """Encode a float column, preserving its incompleteness mask."""
         if colMaskList:
             maskedColDataList = [0.0 if m else d for m, d in zip(colMaskList, colDataList)]
@@ -782,8 +795,7 @@ class BinaryCifEncoders(object):
             maskedColDataList = colDataList
 
         fallbackEncoderList = FLOAT_BYTE_ARRAY_FALLBACK_CHAIN
-        if itemName is None:
-            itemName = canonical_item_name(catName, atName)
+        itemName = self.__getItemName(catName, atName)
         itemConfig = BCIF_CONFIG.get_float_item_config(itemName)
 
         # Configured float items with a fixed factor use their configured

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -36,7 +36,7 @@ import warnings
 from mmcif.api.DataCategoryTyped import DataCategoryTyped, DataCategoryHints
 from mmcif.api.PdbxContainers import CifName
 from mmcif.io.BinaryCifReader import BinaryCifDecoders
-from mmcif.io.config import BCIF_CONFIG
+from mmcif.io.config import BCIF_CONFIG, canonical_item_name, get_forced_type
 
 from mmcif.io.bcif_type_detector import classify_column
 
@@ -125,11 +125,13 @@ class BinaryCifWriter(object):
                     cols = []
                     for ii, atName in enumerate(cObj.getAttributeList()):
                         colDataList = cObj.getColumn(ii)
-                        dataType = self.__getAttributeType(catName, atName, colDataList) if not self.__useStringTypes else "string"
+                        itemName = canonical_item_name(catName, atName)
+                        dataType = self.__getAttributeType(catName, atName, itemName, colDataList) if not self.__useStringTypes else "string"
 
-                        logger.debug("catName %r atName %r dataType %r", catName, atName, dataType)
-                        # Pass category/item names so float columns can use coordinate-specific hints
-                        colMaskDict, encodedColDataList, encodingDictL = self.__encodeColumnData(colDataList, dataType, catName, atName)
+                        logger.debug("itemName %r dataType %r", itemName, dataType)
+                        colMaskDict, encodedColDataList, encodingDictL = self.__encodeColumnData(
+                            colDataList, dataType, itemName
+                        )
                         cols.append(
                             {
                                 self.__toBytes("name"): self.__toBytes(atName),
@@ -152,8 +154,8 @@ class BinaryCifWriter(object):
             logger.exception("Failing with %s", str(e))
         return False
 
-    # Accept category/item names so encoder selection can use column-specific hints
-    def __encodeColumnData(self, colDataList, dataType, catName=None, atName=None):
+    # Accept the canonical item name so encoding policy is resolved only once.
+    def __encodeColumnData(self, colDataList, dataType, itemName=""):
         colMaskDict = None  # Use None when no mask and not {} - per Mol* implementation
         enc = BinaryCifEncoders(defaultStringEncoding=self.__defaultStringEncoding, storeStringsAsBytes=self.__storeStringsAsBytes, useFloat64=self.__useFloat64)
         #
@@ -183,7 +185,7 @@ class BinaryCifWriter(object):
 
         dataEncType = typeEncoderD[dataType]
         # Forward category/item names to the masked encoder
-        colDataEncoded, colDataEncodingDictL = enc.encodeWithMask(colDataList, colMaskList, dataEncType, catName=catName, atName=atName)
+        colDataEncoded, colDataEncodingDictL = enc.encodeWithMask(colDataList, colMaskList, dataEncType, itemName=itemName)
         if colMaskList:
             # Mol* indicates that masks should be encoded as if uint_8
             colMaskListTyped = TypedArray(colMaskList, "unsigned_integer_8")
@@ -206,134 +208,8 @@ class BinaryCifWriter(object):
             logger.exception("Bad type for %r", strVal)
         return strVal
 
-    # Attributes whose values look numeric but must always be encoded as strings.
-    # These are declared as primitive type "char" in the PDBx/mmCIF dictionary.
-    # Auto-detection would wrongly classify them as int or float without this
-    # override (e.g. _audit_conform.dict_version = "5.281" looks like a float).
-    # Key format: "_category.attribute"  (category name with leading underscore,
-    # case-sensitive).
-    _FORCE_STRING_ATTRS = frozenset({
-        "_audit_conform.dict_version",
-        "_audit_conform.dict_location",
-        "_audit_conform.dict_name",
-        "_atom_site.group_PDB",
-        "_atom_site.type_symbol",
-        "_atom_site.label_atom_id",
-        "_atom_site.label_comp_id",
-        "_atom_site.label_asym_id",
-        "_atom_site.auth_comp_id",
-        "_atom_site.auth_asym_id",
-        "_atom_site.auth_atom_id"
-    })
 
-    _FORCE_INTEGER_ATTRS = frozenset({
-        "_atom_site.id",
-        "_atom_site.auth_seq_id",
-        "_atom_site_anisotrop.id",
-        "_atom_site.label_seq_id",
-        "_atom_site.pdbx_PDB_model_num",
-        "_pdbx_struct_mod_residue.auth_seq_id",
-        "_struct_conf.beg_auth_seq_id",
-        "_struct_conf.end_auth_seq_id",
-        "_struct_conn.ptnr1_auth_seq_id",
-        "_struct_conn.ptnr2_auth_seq_id",
-        "_struct_sheet_range.beg_auth_seq_id",
-        "_struct_sheet_range.end_auth_seq_id",
-    })
-
-    _FORCE_FLOAT_ATTRS = frozenset({
-        "_atom_site.Cartn_x",
-        "_atom_site.Cartn_y",
-        "_atom_site.Cartn_z",
-        "_atom_site.occupancy",
-        "_atom_site.B_iso_or_equiv",
-
-        # PDBx/mmCIF chemical component Cartesian coordinates
-        "_chem_comp_atom.model_Cartn_x",
-        "_chem_comp_atom.model_Cartn_y",
-        "_chem_comp_atom.model_Cartn_z",
-        "_chem_comp_atom.pdbx_model_Cartn_x_ideal",
-        "_chem_comp_atom.pdbx_model_Cartn_y_ideal",
-        "_chem_comp_atom.pdbx_model_Cartn_z_ideal",
-
-        # PDBx/mmCIF phasing-site Cartesian coordinates
-        "_phasing_MIR_der_site.Cartn_x",
-        "_phasing_MIR_der_site.Cartn_y",
-        "_phasing_MIR_der_site.Cartn_z",
-        "_pdbx_phasing_MAD_set_site.Cartn_x",
-        "_pdbx_phasing_MAD_set_site.Cartn_y",
-        "_pdbx_phasing_MAD_set_site.Cartn_z",
-
-        # PDBx/mmCIF solvent atom-site mapping coordinates
-        "_pdbx_solvent_atom_site_mapping.Cartn_x",
-        "_pdbx_solvent_atom_site_mapping.Cartn_y",
-        "_pdbx_solvent_atom_site_mapping.Cartn_z",
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_x",
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_y",
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_z",
-
-        # CSM / ModelCIF template Cartesian coordinates
-        "_ma_template_coord.Cartn_x",
-        "_ma_template_coord.Cartn_y",
-        "_ma_template_coord.Cartn_z",
-
-        # IHM starting-model atomic Cartesian coordinates
-        "_ihm_starting_model_coord.Cartn_x",
-        "_ihm_starting_model_coord.Cartn_y",
-        "_ihm_starting_model_coord.Cartn_z",
-
-        # IHM coarse sphere Cartesian coordinates
-        "_ihm_sphere_obj_site.Cartn_x",
-        "_ihm_sphere_obj_site.Cartn_y",
-        "_ihm_sphere_obj_site.Cartn_z",
-
-        # IHM Gaussian-object mean Cartesian coordinates
-        "_ihm_gaussian_obj_site.mean_Cartn_x",
-        "_ihm_gaussian_obj_site.mean_Cartn_y",
-        "_ihm_gaussian_obj_site.mean_Cartn_z",
-
-        # IHM Gaussian-ensemble mean Cartesian coordinates
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_x",
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_y",
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_z",
-
-        # IHM pseudo-site Cartesian coordinates
-        "_ihm_pseudo_site.Cartn_x",
-        "_ihm_pseudo_site.Cartn_y",
-        "_ihm_pseudo_site.Cartn_z",
-
-        # FLR/FPS mean probe position coordinates
-        "_flr_FPS_mean_probe_position.mpp_xcoord",
-        "_flr_FPS_mean_probe_position.mpp_ycoord",
-        "_flr_FPS_mean_probe_position.mpp_zcoord",
-
-        # FLR/FPS MPP atom position coordinates
-        "_flr_FPS_MPP_atom_position.xcoord",
-        "_flr_FPS_MPP_atom_position.ycoord",
-        "_flr_FPS_MPP_atom_position.zcoord",
-    })
-
-    def __getForcedAttributeType(self, catName, atName):
-        """
-        Return forced data type for known attributes.
-
-        This avoids scanning the full column with classify_column()
-        when the attribute type is already known.
-        """
-        atKey = "_%s.%s" % (catName, atName)
-
-        if atKey in self._FORCE_STRING_ATTRS:
-            return "string"
-
-        if atKey in self._FORCE_INTEGER_ATTRS:
-            return "integer"
-
-        if atKey in self._FORCE_FLOAT_ATTRS:
-            return "float"
-
-        return None
-
-    def __getAttributeType(self, catName, atName, colDataList):
+    def __getAttributeType(self, catName, atName, itemName, colDataList):
         """Resolve a column type without changing either legacy path.
 
         Dictionary mode reproduces the original BinaryCifWriter behavior.
@@ -353,17 +229,16 @@ class BinaryCifWriter(object):
             else:
                 dataType = self.__dch.getPdbxItemType(cifDataType)
 
-            # Mol* integer hints only apply to the dictionary-driven path.
-            # In auto-detect mode, every attribute inMolStarIntHints() covers
-            # is already present in _FORCE_INTEGER_ATTRS, so this is a no-op
-            # there — confirmed by diffing the two sets.
+            # Mol* integer hints apply only to the dictionary-driven path.
+            # Auto-detect mode resolves configured integer policy before
+            # falling back to schema-less classification.
             if self.__applyTypes and self.__applyMolStarTypes:
                 nm = CifName().itemName(catName, atName)
                 if self.__dch.inMolStarIntHints(nm):
                     dataType = "integer"
 
         else:
-            forcedType = self.__getForcedAttributeType(catName, atName)
+            forcedType = get_forced_type(itemName)
             if forcedType is not None:
                 logger.debug(
                     "Forced type override applied for %s.%s -> %s",
@@ -479,8 +354,8 @@ class BinaryCifEncoders(object):
             return colDataList.data, encodingDictL
         return colDataList, encodingDictL
 
-    # Accept category/item names for float-column encoding decisions
-    def encodeWithMask(self, colDataList, colMaskList, encodingType, catName=None, atName=None):
+    # Accept a canonical item name while retaining category/item compatibility.
+    def encodeWithMask(self, colDataList, colMaskList, encodingType, catName=None, atName=None, itemName=None):
         """Encode the data using the input mask and encoding type returning encoded data and encoding instructions.
 
         Args:
@@ -488,10 +363,10 @@ class BinaryCifEncoders(object):
             colMaskList (list): incompleteness mask for the input data column
             encodingType (string): encoding type to apply
                 (StringArrayMasked, IntArrayMasked, FloatArrayMasked)
-            catName (str, optional): category name used for float-column
-                encoding decisions. Defaults to None.
-            atName (str, optional): attribute name used for float-column
-                encoding decisions. Defaults to None.
+            catName (str, optional): category name retained for compatibility.
+            atName (str, optional): attribute name retained for compatibility.
+            itemName (str, optional): canonical item name used for configured
+                float encoding decisions.
 
         Returns:
             (list, list ): encoded data column, list of encoding instructions
@@ -502,9 +377,10 @@ class BinaryCifEncoders(object):
             encodedColDataList, encodingDictL = self.stringArrayMaskedEncoder(colDataList, colMaskList)
         elif encodingType == "IntArrayMasked":
             encodedColDataList, encodingDictL = self.intArrayMaskedEncoder(colDataList, colMaskList)
-        # Pass category/item names only to the float encoder
         elif encodingType == "FloatArrayMasked":
-            encodedColDataList, encodingDictL = self.floatArrayMaskedEncoder(colDataList, colMaskList, catName=catName, atName=atName)
+            if itemName is None:
+                itemName = canonical_item_name(catName, atName)
+            encodedColDataList, encodingDictL = self.floatArrayMaskedEncoder(colDataList, colMaskList, itemName=itemName)
         else:
             logger.info("unsupported masked encoding %r", encodingType)
         return encodedColDataList, encodingDictL
@@ -722,16 +598,6 @@ class BinaryCifEncoders(object):
         """
         return all(-2147483648 <= int(v) <= 2147483647 for v in data)
 
-    def __getItemName(self, catName, atName):
-        """Return normalized _category.attribute item name."""
-        if catName is None or atName is None:
-            return ""
-
-        if catName.startswith("_"):
-            return "%s.%s" % (catName, atName)
-        else:
-            return "_%s.%s" % (catName, atName)
-
     def __shouldUseStringFallbackForFloat(self, colDataList):
         """Return True when the column requires high-precision float fallback."""
         for val in colDataList:
@@ -904,7 +770,7 @@ class BinaryCifEncoders(object):
             logger.debug("Falling back from the fixed float chain for %s: %s", itemName, str(e))
             return self.encode(colDataList, ["ByteArray"], "float")
 
-    def floatArrayMaskedEncoder(self, colDataList, colMaskList, catName=None, atName=None):
+    def floatArrayMaskedEncoder(self, colDataList, colMaskList, catName=None, atName=None, itemName=None):
         """Encode a float column, preserving its incompleteness mask."""
         if colMaskList:
             maskedColDataList = [0.0 if m else d for m, d in zip(colMaskList, colDataList)]
@@ -912,7 +778,8 @@ class BinaryCifEncoders(object):
             maskedColDataList = colDataList
 
         fallbackEncoderList = ["ByteArray"]
-        itemName = self.__getItemName(catName, atName)
+        if itemName is None:
+            itemName = canonical_item_name(catName, atName)
         itemConfig = BCIF_CONFIG.get_float_item_config(itemName)
 
         # Forced float items with a fixed factor always use their configured

--- a/mmcif/io/bcif_type_detector.py
+++ b/mmcif/io/bcif_type_detector.py
@@ -8,8 +8,9 @@ Exports
 ColumnProfile   : dataclass holding all classification results for one column
 classify_column : scan a column list once and return a populated ColumnProfile
 
-This module has no dependency on the BinaryCIF writer, the dictionaryApi,
-or any mmcif library.  It can be imported and used independently.
+This module has no dependency on the BinaryCIF writer or dictionaryApi.
+It consumes immutable policy from mmcif.io.config and can otherwise be used
+independently.
 
 The three-way col_type result ("int" | "float" | "str") is a direct
 replacement for the dictionaryApi.getTypeCode() → getPdbxItemType() chain
@@ -21,6 +22,7 @@ ignored if only the basic type is needed.
 
 import re
 from dataclasses import dataclass
+from mmcif.io.config import MISSING_VALUE_TOKENS, TYPE_DETECTION_CONFIG
 from typing import Any
 
 # ---------------------------------------------------------------------------
@@ -30,13 +32,6 @@ from typing import Any
 _INT   = re.compile(r"^-?\d+$")
 _FLOAT = re.compile(r"^-?\d+\.\d*$|^-?\d*\.\d+$")
 
-# BinaryCIF sentinel values — these represent missing/unknown data, not values
-_SENTINELS = {".", "?"}
-
-# If True (default), a column that would otherwise classify as "float" is forced to
-# "str" when it has fewer than _MIN_FLOAT_ROWS present (non-sentinel) values.
-FORCE_SMALL_FLOAT_AS_STRING = True
-MIN_ROWS_TO_CLASSIFY_AS_FLOAT = 3
 
 
 # ---------------------------------------------------------------------------
@@ -82,7 +77,11 @@ class ColumnProfile:
 # classify_column — the single public entry point
 # ---------------------------------------------------------------------------
 
-def classify_column(values: list, force_small_float_as_string: bool = None) -> ColumnProfile:
+def classify_column(
+    values: list,
+    force_small_float_as_string: bool = None,
+    type_detection_config=None,
+) -> ColumnProfile:
     """
     Scan a column once and return a fully populated ColumnProfile.
 
@@ -110,17 +109,24 @@ def classify_column(values: list, force_small_float_as_string: bool = None) -> C
         May contain strings, ints, floats, None, ".", "?".
 
     force_small_float_as_string : bool, optional
-        Overrides the module-level FORCE_SMALL_FLOAT_AS_STRING flag for this
-        call only. If None (default), the module-level flag is used.
-        When effectively True, a column that would classify as "float" but
-        has fewer than 3 present (non-sentinel) values is forced to "str"
-        instead.
+        Compatibility override for the configured small-float switch.
+    type_detection_config : TypeDetectionConfig, optional
+        Immutable policy for this call. Defaults to TYPE_DETECTION_CONFIG.
+        When the effective switch is True, a column that would classify as
+        "float" but has fewer than the configured number of present
+        non-sentinel values is forced to "str".
 
     Returns
     -------
     ColumnProfile
         Fully populated.  col_type is always set to "int", "float", or "str".
     """
+    type_detection_config = type_detection_config or TYPE_DETECTION_CONFIG
+    force_small = (
+        type_detection_config.force_small_float_as_string
+        if force_small_float_as_string is None
+        else force_small_float_as_string
+    )
     p = ColumnProfile()
 
     # type-probe state
@@ -146,7 +152,7 @@ def classify_column(values: list, force_small_float_as_string: bool = None) -> C
     for v in values:
 
         # --- sentinel gate (cheapest check) ---
-        if v is None or v in _SENTINELS:
+        if v is None or v in MISSING_VALUE_TOKENS:
             sentinels += 1
             continue
 
@@ -257,9 +263,8 @@ def classify_column(values: list, force_small_float_as_string: bool = None) -> C
         else:                            p.int_width = "int32"
 
     elif all_float:
-        # Assigns str data type to float columns with less than a set number of rows.
-        force_small = FORCE_SMALL_FLOAT_AS_STRING if force_small_float_as_string is None else force_small_float_as_string
-        if force_small and total < MIN_ROWS_TO_CLASSIFY_AS_FLOAT:
+        # Apply the configurable small-float override only when enabled.
+        if force_small and total < type_detection_config.min_rows_to_classify_as_float:
             p.col_type = "str"
         else:
             p.col_type   = "float"

--- a/mmcif/io/bcif_type_detector.py
+++ b/mmcif/io/bcif_type_detector.py
@@ -14,22 +14,21 @@ independently.
 
 The three-way col_type result ("int" | "float" | "str") is a direct
 replacement for the dictionaryApi.getTypeCode() → getPdbxItemType() chain
-used in BinaryCifWriter.py.  The additional profile fields (int_width,
-max_decimals, is_sequential, has_long_runs, unique_ratio) are available
-to the writer for more precise encoding pipeline selection, but can be
-ignored if only the basic type is needed.
+used in BinaryCifWriter.py. The writer currently consumes only col_type;
+the additional profile fields are retained for callers and future encoding
+pipeline selection.
 """
 
 import re
 from dataclasses import dataclass
-from mmcif.io.config import MISSING_VALUE_TOKENS, TYPE_DETECTION_CONFIG
-from typing import Any
+from typing import Any, Optional
+
+from mmcif.io.config import MISSING_VALUE_TOKENS, TYPE_DETECTION_CONFIG, TypeDetectionConfig
 
 # ---------------------------------------------------------------------------
 # Module-level compiled regex — built once, shared across all calls
 # ---------------------------------------------------------------------------
 
-_INT   = re.compile(r"^-?\d+$")
 _FLOAT = re.compile(r"^-?\d+\.\d*$|^-?\d*\.\d+$")
 
 
@@ -79,8 +78,8 @@ class ColumnProfile:
 
 def classify_column(
     values: list,
-    force_small_float_as_string: bool = None,
-    type_detection_config=None,
+    force_small_float_as_string: Optional[bool] = None,
+    type_detection_config: Optional[TypeDetectionConfig] = None,
 ) -> ColumnProfile:
     """
     Scan a column once and return a fully populated ColumnProfile.

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -10,8 +10,7 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Optional, Tuple
 
-
-MISSING_VALUE_TOKENS = frozenset({".", "?"})
+MISSING_VALUE_TOKENS = frozenset({".", "?"})  # List of sentinels 
 
 FORCED_STRING_ITEMS = frozenset({
     "_audit_conform.dict_version",

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -83,31 +83,12 @@ TYPE_DETECTION_CONFIG = TypeDetectionConfig(
 )
 
 
-@dataclass(frozen=True, init=False)
+@dataclass(frozen=True)
 class FloatEncodingConfig:
     """FixedPoint factor and immutable post-FixedPoint integer chain."""
 
     factor: Optional[int]
     integer_chain: Tuple[str, ...]
-
-    def __init__(self, factor=1000, encoderList=None, integer_chain=None):
-        chain = integer_chain if integer_chain is not None else encoderList
-        chain = tuple(chain or ())
-        if chain and chain[0] == "FixedPoint":
-            chain = chain[1:]
-        object.__setattr__(self, "factor", factor)
-        object.__setattr__(self, "integer_chain", chain)
-
-    @property
-    def encoderList(self):
-        """Compatibility alias for the immutable post-FixedPoint chain."""
-        return self.integer_chain
-
-    def get_float_encoder_list(self):
-        """Return the full fixed-factor chain used by the current writer."""
-        if self.factor is None:
-            return None
-        return (("FixedPoint", self.factor),) + self.integer_chain
 
 
 class BinaryCifEncodingConfig:
@@ -132,102 +113,99 @@ class BinaryCifEncodingConfig:
     #        ByteArray directly without comparing alternative chains.
     COMPARE_ALL_FIXED_POINT_CHAINS = True
 
-    # Used only for items that are NOT in FORCED_FLOAT_ITEMS (general
-    # floats), or for a forced item whose factor is explicitly
-    # set to None (auto-detect), when scanning the column to find the
-    # smallest safe factor.
+    # Used for general floats and configured floats whose factor is None
+    # when scanning the column for the smallest safe factor.
     MAX_FIXED_POINT_DECIMAL_PLACES = 4
     FIXED_POINT_TOLERANCE = 1.0e-6
 
     # -----------------------------------------------------------------------
-    # Forced float data items
+    # Float item configuration
     # -----------------------------------------------------------------------
-    #
-    # Keys are full mmCIF item names, i.e. "_category.attribute".
-    # Values are FloatEncodingConfig(factor, encoderList) instances. Every item
-    # here is assumed to be a float.
+    # Keys are canonical mmCIF item names. Membership implies forced float
+    # typing. Values contain the FixedPoint factor (or None for automatic
+    # resolution) and the immutable integer chain that follows FixedPoint.
     FLOAT_ITEM_CONFIGS = MappingProxyType({
 
         # ---- Cartesian coordinates: factor 1000, FixedPoint -> Delta -> IntegerPacking -> ByteArray ----
         # PDB / standard model coordinates
-        "_atom_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_atom_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_atom_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_atom_site.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_atom_site.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
 
         # PDBx/mmCIF chemical component coordinates
-        "_chem_comp_atom.model_Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_chem_comp_atom.model_Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_chem_comp_atom.model_Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_chem_comp_atom.pdbx_model_Cartn_x_ideal": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_chem_comp_atom.pdbx_model_Cartn_y_ideal": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_chem_comp_atom.pdbx_model_Cartn_z_ideal": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_chem_comp_atom.model_Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_chem_comp_atom.model_Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_chem_comp_atom.model_Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_chem_comp_atom.pdbx_model_Cartn_x_ideal": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_chem_comp_atom.pdbx_model_Cartn_y_ideal": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_chem_comp_atom.pdbx_model_Cartn_z_ideal": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
 
         # PDBx/mmCIF phasing-site coordinates
-        "_phasing_MIR_der_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_phasing_MIR_der_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_phasing_MIR_der_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_pdbx_phasing_MAD_set_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_pdbx_phasing_MAD_set_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_pdbx_phasing_MAD_set_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_phasing_MIR_der_site.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_phasing_MIR_der_site.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_phasing_MIR_der_site.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_pdbx_phasing_MAD_set_site.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_pdbx_phasing_MAD_set_site.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_pdbx_phasing_MAD_set_site.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
 
         # PDBx/mmCIF solvent atom-site mapping coordinates
-        "_pdbx_solvent_atom_site_mapping.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_pdbx_solvent_atom_site_mapping.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_pdbx_solvent_atom_site_mapping.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_solvent_atom_site_mapping.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_pdbx_solvent_atom_site_mapping.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_pdbx_solvent_atom_site_mapping.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
 
         # ModelCIF / CSM template coordinates
-        "_ma_template_coord.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ma_template_coord.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ma_template_coord.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ma_template_coord.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ma_template_coord.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ma_template_coord.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
 
         # IHM coordinates
-        "_ihm_starting_model_coord.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_starting_model_coord.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_starting_model_coord.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_sphere_obj_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_sphere_obj_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_sphere_obj_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_gaussian_obj_site.mean_Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_gaussian_obj_site.mean_Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_gaussian_obj_site.mean_Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_pseudo_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_pseudo_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_pseudo_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_starting_model_coord.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_starting_model_coord.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_starting_model_coord.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_sphere_obj_site.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_sphere_obj_site.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_sphere_obj_site.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_gaussian_obj_site.mean_Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_gaussian_obj_site.mean_Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_gaussian_obj_site.mean_Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_pseudo_site.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_pseudo_site.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_pseudo_site.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
 
         # FLR / FPS coordinates
-        "_flr_FPS_mean_probe_position.mpp_xcoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_flr_FPS_mean_probe_position.mpp_ycoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_flr_FPS_mean_probe_position.mpp_zcoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_flr_FPS_MPP_atom_position.xcoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_flr_FPS_MPP_atom_position.ycoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_flr_FPS_MPP_atom_position.zcoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_flr_FPS_mean_probe_position.mpp_xcoord": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_flr_FPS_mean_probe_position.mpp_ycoord": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_flr_FPS_mean_probe_position.mpp_zcoord": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_flr_FPS_MPP_atom_position.xcoord": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_flr_FPS_MPP_atom_position.ycoord": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_flr_FPS_MPP_atom_position.zcoord": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
 
         # ---- Anisotropic displacement U matrix: factor 10000, FixedPoint -> Delta -> IntegerPacking -> ByteArray ----
-        "_atom_site_anisotrop.U[1][1]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_atom_site_anisotrop.U[1][2]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_atom_site_anisotrop.U[1][3]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_atom_site_anisotrop.U[2][2]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_atom_site_anisotrop.U[2][3]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_atom_site_anisotrop.U[3][3]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site_anisotrop.U[1][1]": FloatEncodingConfig(10000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_atom_site_anisotrop.U[1][2]": FloatEncodingConfig(10000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_atom_site_anisotrop.U[1][3]": FloatEncodingConfig(10000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_atom_site_anisotrop.U[2][2]": FloatEncodingConfig(10000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_atom_site_anisotrop.U[2][3]": FloatEncodingConfig(10000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_atom_site_anisotrop.U[3][3]": FloatEncodingConfig(10000, ("Delta", "IntegerPacking", "ByteArray")),
 
         # ---- IHM sphere object radius: factor 1000, no Delta/RunLength ----
-        "_ihm_sphere_obj_site.object_radius": FloatEncodingConfig(1000, ["FixedPoint", "IntegerPacking", "ByteArray"]),
+        "_ihm_sphere_obj_site.object_radius": FloatEncodingConfig(1000, ("IntegerPacking", "ByteArray")),
 
         # ---- High-volume float items: factor auto-detected from data, RunLength chain ----
         # NOTE: Setting factor=None means the caller is expected to auto-detect a safe factor from the column's data,
         #       and prepend the "FixedPoint" step to the encoder list with that factor.
-        "_atom_site.occupancy": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+        "_atom_site.occupancy": FloatEncodingConfig(None, ("RunLength", "IntegerPacking", "ByteArray")),
 
-        "_atom_site.B_iso_or_equiv": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
-        "_ihm_sphere_obj_site.rmsf": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+        "_atom_site.B_iso_or_equiv": FloatEncodingConfig(None, ("RunLength", "IntegerPacking", "ByteArray")),
+        "_ihm_sphere_obj_site.rmsf": FloatEncodingConfig(None, ("RunLength", "IntegerPacking", "ByteArray")),
 
-        "_ihm_starting_model_coord.B_iso_or_equiv": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+        "_ihm_starting_model_coord.B_iso_or_equiv": FloatEncodingConfig(None, ("RunLength", "IntegerPacking", "ByteArray")),
     })
 
     # -----------------------------------------------------------------------
@@ -245,26 +223,6 @@ class BinaryCifEncodingConfig:
             FloatEncodingConfig or None
         """
         return cls.FLOAT_ITEM_CONFIGS.get(itemName)
-
-    @classmethod
-    def get_float_encoder_list(cls, itemName):
-        """Return the resolved encoder list for itemName, if it is a forced type.
-
-        Any "FixedPoint" entry in the item's encoderList is replaced with the
-        tuple ("FixedPoint", factor), using that item's own factor.
-
-        Args:
-            itemName (str): full item name, e.g. "_atom_site.Cartn_x"
-
-        Returns:
-            list or None: the resolved encoder list, or None if itemName is
-            not in FORCED_FLOAT_ITEMS, or if it has no pre-determined
-            encoderList.
-        """
-        itemConfig = cls.get_float_item_config(itemName)
-        if itemConfig is None:
-            return None
-        return itemConfig.get_float_encoder_list()
 
 
 FLOAT_ITEM_CONFIGS = BinaryCifEncodingConfig.FLOAT_ITEM_CONFIGS

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -2,71 +2,111 @@
 # File: config.py
 # Date: 06-Jul-2026
 #
-# Configuration settings, primarily for BinaryCifWriter.py encoding behavior.
+# BinaryCIF domain policy and reusable encoding configuration.
 #
 ##
 
-_UNSET = object()
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Optional, Tuple
 
 
-def _set_float_item_names(itemConfigs):
-    """Populate each FloatEncodingConfig.name from its dictionary key."""
-    for itemName, itemConfig in itemConfigs.items():
-        itemConfig.name = itemName
-    return itemConfigs
+MISSING_VALUE_TOKENS = frozenset({".", "?"})
+
+FORCED_STRING_ITEMS = frozenset({
+    "_audit_conform.dict_version",
+    "_audit_conform.dict_location",
+    "_audit_conform.dict_name",
+    "_atom_site.group_PDB",
+    "_atom_site.type_symbol",
+    "_atom_site.label_atom_id",
+    "_atom_site.label_comp_id",
+    "_atom_site.label_asym_id",
+    "_atom_site.auth_comp_id",
+    "_atom_site.auth_asym_id",
+    "_atom_site.auth_atom_id",
+})
+
+FORCED_INTEGER_ITEMS = frozenset({
+    "_atom_site.id",
+    "_atom_site.auth_seq_id",
+    "_atom_site_anisotrop.id",
+    "_atom_site.label_seq_id",
+    "_atom_site.pdbx_PDB_model_num",
+    "_pdbx_struct_mod_residue.auth_seq_id",
+    "_struct_conf.beg_auth_seq_id",
+    "_struct_conf.end_auth_seq_id",
+    "_struct_conn.ptnr1_auth_seq_id",
+    "_struct_conn.ptnr2_auth_seq_id",
+    "_struct_sheet_range.beg_auth_seq_id",
+    "_struct_sheet_range.end_auth_seq_id",
+})
+
+SUPPORTED_ENCODERS = frozenset({"FixedPoint", "Delta", "RunLength", "IntegerPacking", "ByteArray"})
+DEFAULT_INTEGER_CHAIN = ("Delta", "RunLength", "IntegerPacking", "ByteArray")
+MASK_ENCODING_CHAIN = ("RunLength", "ByteArray")
+FLOAT_BYTE_ARRAY_FALLBACK_CHAIN = ("ByteArray",)
+DEFAULT_FIXED_POINT_INTEGER_CHAIN = ("Delta", "RunLength", "IntegerPacking", "ByteArray")
+FIXED_POINT_CANDIDATE_INTEGER_CHAINS = (
+    ("IntegerPacking", "ByteArray"),
+    ("RunLength", "IntegerPacking", "ByteArray"),
+    ("Delta", "IntegerPacking", "ByteArray"),
+    ("Delta", "RunLength", "IntegerPacking", "ByteArray"),
+)
 
 
+@dataclass(frozen=True)
+class TypeDetectionConfig:
+    """Immutable schema-less type-detection policy."""
+
+    force_small_float_as_string: bool = True
+    min_rows_to_classify_as_float: int = 3
+
+    def __post_init__(self):
+        if not isinstance(self.min_rows_to_classify_as_float, int) or isinstance(self.min_rows_to_classify_as_float, bool):
+            raise TypeError("min_rows_to_classify_as_float must be an integer")
+        if self.min_rows_to_classify_as_float < 1:
+            raise ValueError("min_rows_to_classify_as_float must be positive")
+
+
+# If True, a column that would otherwise classify as "float" is forced to
+# "str" when it has fewer than MIN_ROWS_TO_CLASSIFY_AS_FLOAT present
+# non-sentinel values.
+#
+# Keep enabled temporarily while policy is moved without changing behavior.
+FORCE_SMALL_FLOAT_AS_STRING = True
+MIN_ROWS_TO_CLASSIFY_AS_FLOAT = 3
+TYPE_DETECTION_CONFIG = TypeDetectionConfig(
+    force_small_float_as_string=FORCE_SMALL_FLOAT_AS_STRING,
+    min_rows_to_classify_as_float=MIN_ROWS_TO_CLASSIFY_AS_FLOAT,
+)
+
+
+@dataclass(frozen=True, init=False)
 class FloatEncodingConfig:
-    """Describes how a single float data item should be encoded.
+    """FixedPoint factor and immutable post-FixedPoint integer chain."""
 
-    All items tracked via FloatEncodingConfig are assumed to be floats.
+    factor: Optional[int]
+    integer_chain: Tuple[str, ...]
 
-    Attributes:
-        name (str): full item name, e.g. "_atom_site.Cartn_x"
-        factor (int or None): FixedPoint scaling factor.
-            - Not provided (default) -> 1000. (This is what _UNSET is for.)
-            - Provided as None -> no fixed factor; the caller is expected to
-              auto-detect a safe factor from the column's data (used below
-              for a handful of high-volume items that need this today).
-            - Provided as an int -> always use that fixed factor.
-        encoderList (list or None): the encoder chain for this item, e.g.
-            ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]. Include
-            the literal string "FixedPoint" wherever the FixedPoint step
-            belongs in the chain; get_float_encoder_list() will substitute in
-            the actual factor. Defaults to None (no pre-determined chain).
-    """
+    def __init__(self, factor=1000, encoderList=None, integer_chain=None):
+        chain = integer_chain if integer_chain is not None else encoderList
+        chain = tuple(chain or ())
+        if chain and chain[0] == "FixedPoint":
+            chain = chain[1:]
+        object.__setattr__(self, "factor", factor)
+        object.__setattr__(self, "integer_chain", chain)
 
-    def __init__(self, factor=_UNSET, encoderList=None, name=None):
-        self.name = name
-        self.factor = 1000 if factor is _UNSET else factor
-        self.encoderList = encoderList
+    @property
+    def encoderList(self):
+        """Compatibility alias for the immutable post-FixedPoint chain."""
+        return self.integer_chain
 
     def get_float_encoder_list(self):
-        """Return this item's encoder list, with any "FixedPoint" entry
-        replaced by the tuple ("FixedPoint", self.factor).
-
-        Returns:
-            list or None: the resolved encoder list, or None if this item
-            has no pre-determined encoderList.
-        """
-        if self.encoderList is None:
+        """Return the full fixed-factor chain used by the current writer."""
+        if self.factor is None:
             return None
-        procEncoderList = []
-        for enc in self.encoderList:
-            if enc == "FixedPoint":
-                if self.factor is None:
-                    raise ValueError(f"Forced float data item {self.name} with encoder list {self.encoderList} must have a factor defined for 'FixedPoint' encoding ({self.factor})")
-                procEncoderList.append(("FixedPoint", self.factor))
-            else:
-                procEncoderList.append(enc)
-        return procEncoderList
-
-    def __repr__(self):
-        return "FloatEncodingConfig(name=%r, factor=%r, encoderList=%r)" % (
-            self.name,
-            self.factor,
-            self.encoderList,
-        )
+        return (("FixedPoint", self.factor),) + self.integer_chain
 
 
 class BinaryCifEncodingConfig:
@@ -105,7 +145,7 @@ class BinaryCifEncodingConfig:
     # Keys are full mmCIF item names, i.e. "_category.attribute".
     # Values are FloatEncodingConfig(factor, encoderList) instances. Every item
     # here is assumed to be a float.
-    FORCED_FLOAT_ITEMS = _set_float_item_names({
+    FLOAT_ITEM_CONFIGS = MappingProxyType({
 
         # ---- Cartesian coordinates: factor 1000, FixedPoint -> Delta -> IntegerPacking -> ByteArray ----
         # PDB / standard model coordinates
@@ -182,8 +222,10 @@ class BinaryCifEncodingConfig:
         # NOTE: Setting factor=None means the caller is expected to auto-detect a safe factor from the column's data,
         #       and prepend the "FixedPoint" step to the encoder list with that factor.
         "_atom_site.occupancy": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+
         "_atom_site.B_iso_or_equiv": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
         "_ihm_sphere_obj_site.rmsf": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+
         "_ihm_starting_model_coord.B_iso_or_equiv": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
     })
 
@@ -201,7 +243,7 @@ class BinaryCifEncodingConfig:
         Returns:
             FloatEncodingConfig or None
         """
-        return cls.FORCED_FLOAT_ITEMS.get(itemName)
+        return cls.FLOAT_ITEM_CONFIGS.get(itemName)
 
     @classmethod
     def get_float_encoder_list(cls, itemName):
@@ -224,4 +266,66 @@ class BinaryCifEncodingConfig:
         return itemConfig.get_float_encoder_list()
 
 
+FLOAT_ITEM_CONFIGS = BinaryCifEncodingConfig.FLOAT_ITEM_CONFIGS
+
+
+def canonical_item_name(category_name, attribute_name):
+    """Return the canonical, case-sensitive _category.attribute name."""
+    if category_name is None or attribute_name is None:
+        return ""
+    if category_name.startswith("_"):
+        return "%s.%s" % (category_name, attribute_name)
+    return "_%s.%s" % (category_name, attribute_name)
+
+
+def get_forced_type(item_name):
+    """Return a configured writer type for a canonical item name, if any."""
+    if item_name in FORCED_STRING_ITEMS:
+        return "string"
+    if item_name in FORCED_INTEGER_ITEMS:
+        return "integer"
+    if item_name in FLOAT_ITEM_CONFIGS:
+        return "float"
+    return None
+
+
+def validate_binary_cif_config():
+    """Raise ValueError for contradictory or unsupported BinaryCIF policy."""
+    errors = []
+    if FORCED_STRING_ITEMS & FORCED_INTEGER_ITEMS:
+        errors.append("items cannot be both forced string and forced integer")
+    if FORCED_STRING_ITEMS & set(FLOAT_ITEM_CONFIGS):
+        errors.append("forced string items cannot have float configurations")
+    if FORCED_INTEGER_ITEMS & set(FLOAT_ITEM_CONFIGS):
+        errors.append("forced integer items cannot have float configurations")
+
+    reusable_chains = FIXED_POINT_CANDIDATE_INTEGER_CHAINS + (
+        DEFAULT_FIXED_POINT_INTEGER_CHAIN,
+        DEFAULT_INTEGER_CHAIN,
+        FLOAT_BYTE_ARRAY_FALLBACK_CHAIN,
+        MASK_ENCODING_CHAIN,
+    )
+    for chain in reusable_chains:
+        unsupported = set(chain) - SUPPORTED_ENCODERS
+        if unsupported:
+            errors.append("unsupported encoders: %s" % sorted(unsupported))
+
+    for item_name, item_config in FLOAT_ITEM_CONFIGS.items():
+        if item_config.factor is not None and (
+            not isinstance(item_config.factor, int)
+            or isinstance(item_config.factor, bool)
+            or item_config.factor <= 0
+        ):
+            errors.append("%s has an invalid FixedPoint factor" % item_name)
+        unsupported = set(item_config.integer_chain) - SUPPORTED_ENCODERS
+        if unsupported:
+            errors.append("%s has unsupported encoders: %s" % (item_name, sorted(unsupported)))
+
+    if errors:
+        raise ValueError("; ".join(errors))
+    return True
+
+
 BCIF_CONFIG = BinaryCifEncodingConfig()
+
+validate_binary_cif_config()

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -214,7 +214,7 @@ class BinaryCifEncodingConfig:
 
     @classmethod
     def get_float_item_config(cls, itemName):
-        """Return the FloatEncodingConfig for itemName, or None if it isn't a forced type.
+        """Return the FloatEncodingConfig for itemName, or None if it is not configured.
 
         Args:
             itemName (str): full item name, e.g. "_atom_site.Cartn_x"

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -59,7 +59,7 @@ FIXED_POINT_CANDIDATE_INTEGER_CHAINS = (
 class TypeDetectionConfig:
     """Immutable schema-less type-detection policy."""
 
-    force_small_float_as_string: bool = True
+    force_small_float_as_string: bool = False
     min_rows_to_classify_as_float: int = 3
 
     def __post_init__(self):
@@ -73,8 +73,9 @@ class TypeDetectionConfig:
 # "str" when it has fewer than MIN_ROWS_TO_CLASSIFY_AS_FLOAT present
 # non-sentinel values.
 #
-# Keep enabled temporarily while policy is moved without changing behavior.
-FORCE_SMALL_FLOAT_AS_STRING = True
+# Keep disabled by default. Enabling this may increase BCIF file size by
+# up to 7%.
+FORCE_SMALL_FLOAT_AS_STRING = False
 MIN_ROWS_TO_CLASSIFY_AS_FLOAT = 3
 TYPE_DETECTION_CONFIG = TypeDetectionConfig(
     force_small_float_as_string=FORCE_SMALL_FLOAT_AS_STRING,

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -2,7 +2,7 @@
 # File: config.py
 # Date: 06-Jul-2026
 #
-# BinaryCIF domain policy and reusable encoding configuration.
+# Configuration settings, primarily for BinaryCifWriter.py encoding behavior.
 #
 ##
 
@@ -10,7 +10,8 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Optional, Tuple
 
-MISSING_VALUE_TOKENS = frozenset({".", "?"})  # List of sentinels 
+
+MISSING_VALUE_TOKENS = frozenset({".", "?"})  # List of sentinels
 
 FORCED_STRING_ITEMS = frozenset({
     "_audit_conform.dict_version",
@@ -227,15 +228,6 @@ class BinaryCifEncodingConfig:
 
 
 FORCED_FLOAT_ITEMS = BinaryCifEncodingConfig.FLOAT_ITEM_CONFIGS
-
-
-def canonical_item_name(category_name, attribute_name):
-    """Return the canonical, case-sensitive _category.attribute name."""
-    if category_name is None or attribute_name is None:
-        return ""
-    if category_name.startswith("_"):
-        return "%s.%s" % (category_name, attribute_name)
-    return "_%s.%s" % (category_name, attribute_name)
 
 
 def get_forced_type(item_name):

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -225,7 +225,7 @@ class BinaryCifEncodingConfig:
         return cls.FLOAT_ITEM_CONFIGS.get(itemName)
 
 
-FLOAT_ITEM_CONFIGS = BinaryCifEncodingConfig.FLOAT_ITEM_CONFIGS
+FORCED_FLOAT_ITEMS = BinaryCifEncodingConfig.FLOAT_ITEM_CONFIGS
 
 
 def canonical_item_name(category_name, attribute_name):
@@ -243,7 +243,7 @@ def get_forced_type(item_name):
         return "string"
     if item_name in FORCED_INTEGER_ITEMS:
         return "integer"
-    if item_name in FLOAT_ITEM_CONFIGS:
+    if item_name in FORCED_FLOAT_ITEMS:
         return "float"
     return None
 
@@ -253,9 +253,9 @@ def validate_binary_cif_config():
     errors = []
     if FORCED_STRING_ITEMS & FORCED_INTEGER_ITEMS:
         errors.append("items cannot be both forced string and forced integer")
-    if FORCED_STRING_ITEMS & set(FLOAT_ITEM_CONFIGS):
+    if FORCED_STRING_ITEMS & set(FORCED_FLOAT_ITEMS):
         errors.append("forced string items cannot have float configurations")
-    if FORCED_INTEGER_ITEMS & set(FLOAT_ITEM_CONFIGS):
+    if FORCED_INTEGER_ITEMS & set(FORCED_FLOAT_ITEMS):
         errors.append("forced integer items cannot have float configurations")
 
     reusable_chains = FIXED_POINT_CANDIDATE_INTEGER_CHAINS + (
@@ -269,7 +269,7 @@ def validate_binary_cif_config():
         if unsupported:
             errors.append("unsupported encoders: %s" % sorted(unsupported))
 
-    for item_name, item_config in FLOAT_ITEM_CONFIGS.items():
+    for item_name, item_config in FORCED_FLOAT_ITEMS.items():
         if item_config.factor is not None and (
             not isinstance(item_config.factor, int)
             or isinstance(item_config.factor, bool)

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -122,8 +122,12 @@ class BinaryCifEncodingConfig:
     # Float item configuration
     # -----------------------------------------------------------------------
     # Keys are canonical mmCIF item names. Membership implies forced float
-    # typing. Values contain the FixedPoint factor (or None for automatic
-    # resolution) and the immutable integer chain that follows FixedPoint.
+    # typing. Each configuration contains a FixedPoint factor and the immutable
+    # integer encoding chain applied after FixedPoint.
+    #
+    # BinaryCifWriter always prepends ("FixedPoint", factor) to the configured
+    # integer chain. If factor is an integer, that value is used. If factor=None,
+    # the writer first detects a safe factor from the column data.
     FLOAT_ITEM_CONFIGS = MappingProxyType({
 
         # ---- Cartesian coordinates: factor 1000, FixedPoint -> Delta -> IntegerPacking -> ByteArray ----
@@ -198,8 +202,6 @@ class BinaryCifEncodingConfig:
         "_ihm_sphere_obj_site.object_radius": FloatEncodingConfig(1000, ("IntegerPacking", "ByteArray")),
 
         # ---- High-volume float items: factor auto-detected from data, RunLength chain ----
-        # NOTE: Setting factor=None means the caller is expected to auto-detect a safe factor from the column's data,
-        #       and prepend the "FixedPoint" step to the encoder list with that factor.
         "_atom_site.occupancy": FloatEncodingConfig(None, ("RunLength", "IntegerPacking", "ByteArray")),
 
         "_atom_site.B_iso_or_equiv": FloatEncodingConfig(None, ("RunLength", "IntegerPacking", "ByteArray")),

--- a/mmcif/tests/testBcifTypeDetector.py
+++ b/mmcif/tests/testBcifTypeDetector.py
@@ -1,0 +1,83 @@
+##
+# File: testBcifTypeDetector.py
+#
+# Characterization tests for schema-less BinaryCIF column classification.
+##
+
+import unittest
+
+from mmcif.io.bcif_type_detector import classify_column
+from mmcif.io.config import TypeDetectionConfig
+
+
+class BcifTypeDetectorTests(unittest.TestCase):
+    def assertColumnType(self, expected, values, config=None):
+        profile = classify_column(values, type_detection_config=config)
+        self.assertEqual(profile.col_type, expected)
+
+    def testNumericAndStringCharacterization(self):
+        cases = [
+            ("int", ["1", "2", "3"]),
+            ("int", [1, 2, 3]),
+            ("float", ["1.25", "2.50", "3.75"]),
+            ("float", [1.25, 2.5, 3.75]),
+            ("int", ["-3", "-2", "-1"]),
+            ("float", ["-3.5", "-2.5", "-1.5"]),
+            ("str", ["0004"]),
+            ("str", ["1e-3", "2e-3", "3e-3"]),
+            ("str", [True, False]),
+            ("int", [".", "?", None]),
+            ("int", [".", "1", "?", "2"]),
+            ("float", [".", "1.5", "?", "2.5", "3.5"]),
+            ("str", [".", "alpha", "?", "beta"]),
+            ("str", ["1", "2.5", "3"]),
+            ("int", []),
+            ("int", [" 1 ", " 2 ", " 3 "]),
+            ("float", [" 1.5 ", " 2.5 ", " 3.5 "]),
+        ]
+        for expected, values in cases:
+            with self.subTest(values=values):
+                self.assertColumnType(expected, values)
+
+    def testSmallFloatOverrideDisabled(self):
+        config = TypeDetectionConfig(
+            force_small_float_as_string=False,
+            min_rows_to_classify_as_float=3,
+        )
+        for values in (["1.5"], ["1.5", "2.5"], ["1.5", "2.5", "3.5"]):
+            with self.subTest(values=values):
+                self.assertColumnType("float", values, config)
+
+    def testSmallFloatOverrideEnabled(self):
+        config = TypeDetectionConfig(
+            force_small_float_as_string=True,
+            min_rows_to_classify_as_float=3,
+        )
+        self.assertColumnType("str", ["1.5"], config)
+        self.assertColumnType("str", ["1.5", "2.5"], config)
+        self.assertColumnType("float", ["1.5", "2.5", "3.5"], config)
+
+    def testSentinelsDoNotCountTowardSmallFloatThreshold(self):
+        config = TypeDetectionConfig(
+            force_small_float_as_string=True,
+            min_rows_to_classify_as_float=3,
+        )
+        self.assertColumnType("str", [".", "1.5", "?", "2.5", None], config)
+        self.assertColumnType("float", [".", "1.5", "?", "2.5", "3.5"], config)
+
+    def testConfiguredThresholdOnlyAffectsEnabledOverride(self):
+        enabled = TypeDetectionConfig(
+            force_small_float_as_string=True,
+            min_rows_to_classify_as_float=2,
+        )
+        disabled = TypeDetectionConfig(
+            force_small_float_as_string=False,
+            min_rows_to_classify_as_float=99,
+        )
+        self.assertColumnType("str", ["1.5"], enabled)
+        self.assertColumnType("float", ["1.5", "2.5"], enabled)
+        self.assertColumnType("float", ["1.5"], disabled)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mmcif/tests/testBinaryCifConfig.py
+++ b/mmcif/tests/testBinaryCifConfig.py
@@ -1,0 +1,81 @@
+##
+# File: testBinaryCifConfig.py
+#
+# Invariants for centralized BinaryCIF policy and reusable encoding chains.
+##
+
+import unittest
+
+from mmcif.io.config import (
+    DEFAULT_FIXED_POINT_INTEGER_CHAIN,
+    DEFAULT_INTEGER_CHAIN,
+    FIXED_POINT_CANDIDATE_INTEGER_CHAINS,
+    FLOAT_BYTE_ARRAY_FALLBACK_CHAIN,
+    FLOAT_ITEM_CONFIGS,
+    FORCED_INTEGER_ITEMS,
+    FORCED_STRING_ITEMS,
+    MASK_ENCODING_CHAIN,
+    MISSING_VALUE_TOKENS,
+    SUPPORTED_ENCODERS,
+    TYPE_DETECTION_CONFIG,
+    canonical_item_name,
+    get_forced_type,
+    validate_binary_cif_config,
+)
+
+
+class BinaryCifConfigTests(unittest.TestCase):
+    def testItemPoliciesDoNotConflict(self):
+        self.assertFalse(FORCED_STRING_ITEMS & FORCED_INTEGER_ITEMS)
+        self.assertFalse(FORCED_STRING_ITEMS & set(FLOAT_ITEM_CONFIGS))
+        self.assertFalse(FORCED_INTEGER_ITEMS & set(FLOAT_ITEM_CONFIGS))
+
+    def testEveryFloatConfigForcesFloatType(self):
+        for item_name in FLOAT_ITEM_CONFIGS:
+            with self.subTest(item_name=item_name):
+                self.assertEqual(get_forced_type(item_name), "float")
+
+    def testEncoderNamesAndFactorsAreValid(self):
+        chains = list(FIXED_POINT_CANDIDATE_INTEGER_CHAINS) + [
+            DEFAULT_FIXED_POINT_INTEGER_CHAIN,
+            DEFAULT_INTEGER_CHAIN,
+            FLOAT_BYTE_ARRAY_FALLBACK_CHAIN,
+            MASK_ENCODING_CHAIN,
+        ]
+        for chain in chains:
+            self.assertIsInstance(chain, tuple)
+            self.assertTrue(set(chain) <= SUPPORTED_ENCODERS)
+
+        for item_name, item_config in FLOAT_ITEM_CONFIGS.items():
+            with self.subTest(item_name=item_name):
+                self.assertIsInstance(item_config.integer_chain, tuple)
+                self.assertTrue(set(item_config.integer_chain) <= SUPPORTED_ENCODERS)
+                if item_config.factor is not None:
+                    self.assertIsInstance(item_config.factor, int)
+                    self.assertGreater(item_config.factor, 0)
+
+    def testReusableConfigurationIsImmutable(self):
+        self.assertIsInstance(MISSING_VALUE_TOKENS, frozenset)
+        self.assertIsInstance(FORCED_STRING_ITEMS, frozenset)
+        self.assertIsInstance(FORCED_INTEGER_ITEMS, frozenset)
+        self.assertIsInstance(FIXED_POINT_CANDIDATE_INTEGER_CHAINS, tuple)
+        with self.assertRaises(TypeError):
+            FLOAT_ITEM_CONFIGS["_test.value"] = object()
+
+    def testCanonicalItemNamesAndForcedLookup(self):
+        self.assertEqual(canonical_item_name("atom_site", "Cartn_x"), "_atom_site.Cartn_x")
+        self.assertEqual(canonical_item_name("_atom_site", "Cartn_x"), "_atom_site.Cartn_x")
+        self.assertEqual(get_forced_type("_audit_conform.dict_version"), "string")
+        self.assertEqual(get_forced_type("_atom_site.id"), "integer")
+        self.assertIsNone(get_forced_type("_task1_test.unconfigured"))
+
+    def testDefaultTypeDetectionPolicy(self):
+        self.assertFalse(TYPE_DETECTION_CONFIG.force_small_float_as_string)
+        self.assertEqual(TYPE_DETECTION_CONFIG.min_rows_to_classify_as_float, 3)
+
+    def testValidationHelperAcceptsDefaultConfiguration(self):
+        self.assertTrue(validate_binary_cif_config())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mmcif/tests/testBinaryCifConfig.py
+++ b/mmcif/tests/testBinaryCifConfig.py
@@ -18,7 +18,6 @@ from mmcif.io.config import (
     MISSING_VALUE_TOKENS,
     SUPPORTED_ENCODERS,
     TYPE_DETECTION_CONFIG,
-    canonical_item_name,
     get_forced_type,
     validate_binary_cif_config,
 )
@@ -62,9 +61,7 @@ class BinaryCifConfigTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             FORCED_FLOAT_ITEMS["_test.value"] = object()
 
-    def testCanonicalItemNamesAndForcedLookup(self):
-        self.assertEqual(canonical_item_name("atom_site", "Cartn_x"), "_atom_site.Cartn_x")
-        self.assertEqual(canonical_item_name("_atom_site", "Cartn_x"), "_atom_site.Cartn_x")
+    def testForcedTypeLookup(self):
         self.assertEqual(get_forced_type("_audit_conform.dict_version"), "string")
         self.assertEqual(get_forced_type("_atom_site.id"), "integer")
         self.assertIsNone(get_forced_type("_task1_test.unconfigured"))

--- a/mmcif/tests/testBinaryCifConfig.py
+++ b/mmcif/tests/testBinaryCifConfig.py
@@ -11,7 +11,7 @@ from mmcif.io.config import (
     DEFAULT_INTEGER_CHAIN,
     FIXED_POINT_CANDIDATE_INTEGER_CHAINS,
     FLOAT_BYTE_ARRAY_FALLBACK_CHAIN,
-    FLOAT_ITEM_CONFIGS,
+    FORCED_FLOAT_ITEMS,
     FORCED_INTEGER_ITEMS,
     FORCED_STRING_ITEMS,
     MASK_ENCODING_CHAIN,
@@ -27,11 +27,11 @@ from mmcif.io.config import (
 class BinaryCifConfigTests(unittest.TestCase):
     def testItemPoliciesDoNotConflict(self):
         self.assertFalse(FORCED_STRING_ITEMS & FORCED_INTEGER_ITEMS)
-        self.assertFalse(FORCED_STRING_ITEMS & set(FLOAT_ITEM_CONFIGS))
-        self.assertFalse(FORCED_INTEGER_ITEMS & set(FLOAT_ITEM_CONFIGS))
+        self.assertFalse(FORCED_STRING_ITEMS & set(FORCED_FLOAT_ITEMS))
+        self.assertFalse(FORCED_INTEGER_ITEMS & set(FORCED_FLOAT_ITEMS))
 
     def testEveryFloatConfigForcesFloatType(self):
-        for item_name in FLOAT_ITEM_CONFIGS:
+        for item_name in FORCED_FLOAT_ITEMS:
             with self.subTest(item_name=item_name):
                 self.assertEqual(get_forced_type(item_name), "float")
 
@@ -46,7 +46,7 @@ class BinaryCifConfigTests(unittest.TestCase):
             self.assertIsInstance(chain, tuple)
             self.assertTrue(set(chain) <= SUPPORTED_ENCODERS)
 
-        for item_name, item_config in FLOAT_ITEM_CONFIGS.items():
+        for item_name, item_config in FORCED_FLOAT_ITEMS.items():
             with self.subTest(item_name=item_name):
                 self.assertIsInstance(item_config.integer_chain, tuple)
                 self.assertTrue(set(item_config.integer_chain) <= SUPPORTED_ENCODERS)
@@ -60,7 +60,7 @@ class BinaryCifConfigTests(unittest.TestCase):
         self.assertIsInstance(FORCED_INTEGER_ITEMS, frozenset)
         self.assertIsInstance(FIXED_POINT_CANDIDATE_INTEGER_CHAINS, tuple)
         with self.assertRaises(TypeError):
-            FLOAT_ITEM_CONFIGS["_test.value"] = object()
+            FORCED_FLOAT_ITEMS["_test.value"] = object()
 
     def testCanonicalItemNamesAndForcedLookup(self):
         self.assertEqual(canonical_item_name("atom_site", "Cartn_x"), "_atom_site.Cartn_x")

--- a/mmcif/tests/testBinaryCifWriter.py
+++ b/mmcif/tests/testBinaryCifWriter.py
@@ -147,7 +147,7 @@ class BinaryCifWriterTests(unittest.TestCase):
         dictionaryApi=None) end to end: raw (untyped) containers in -> BCIF out ->
         BcifPrint structural verification -> BinaryCifReader round trip -> value-level
         comparison against the same raw input cast the way the auto-detect classifier
-        (bcif_type_detector.classify_column / the writer's _FORCE_* override tables)
+        (centralized item policy / bcif_type_detector.classify_column)
         is expected to cast it.
  
         Note this intentionally does NOT route the input through DataCategoryTyped/

--- a/mmcif/tests/testBinaryCifWriterSynthetic.py
+++ b/mmcif/tests/testBinaryCifWriterSynthetic.py
@@ -1,0 +1,99 @@
+##
+# File: testBinaryCifWriterSynthetic.py
+#
+# Small writer-level tests for centralized BinaryCIF type policy.
+##
+
+import os
+import tempfile
+import unittest
+
+import msgpack
+
+from mmcif.api.DataCategory import DataCategory
+from mmcif.api.PdbxContainers import DataContainer
+from mmcif.io.BinaryCifReader import BinaryCifReader
+from mmcif.io.BinaryCifWriter import BinaryCifWriter
+
+
+class BinaryCifWriterSyntheticTests(unittest.TestCase):
+    def _serialize_column(self, category_name, attribute_name, values):
+        category = DataCategory(category_name)
+        category.appendAttribute(attribute_name)
+        for value in values:
+            category.append([value])
+
+        container = DataContainer("task1")
+        container.append(category)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_path = os.path.join(tmp_dir, "column.bcif")
+            writer = BinaryCifWriter(dictionaryApi=None, useAutoDetect=True)
+            self.assertTrue(writer.serialize(file_path, [container]))
+            with open(file_path, "rb") as input_file:
+                packed = msgpack.unpack(input_file, raw=False)
+            decoded = BinaryCifReader(storeStringsAsBytes=False).deserialize(file_path)
+
+        column = packed["dataBlocks"][0]["categories"][0]["columns"][0]
+        decoded_category = decoded[0].getObj(category_name)
+        attribute_index = decoded_category.getAttributeIndex(attribute_name)
+        decoded_values = decoded_category.getColumn(attribute_index)
+        return column, decoded_values
+
+    def _encoding_kinds(self, column):
+        return [encoding["kind"] for encoding in column["data"]["encoding"]]
+
+    def assertFloatPath(self, category_name, attribute_name, values):
+        column, decoded_values = self._serialize_column(category_name, attribute_name, values)
+        self.assertIn("FixedPoint", self._encoding_kinds(column))
+        self.assertEqual([float(value) for value in values], decoded_values)
+
+    def testOneRowFloatConfiguredItemsReachFloatPath(self):
+        cases = [
+            ("atom_site_anisotrop", "U[1][1]", ["0.1234"]),
+            ("ihm_sphere_obj_site", "object_radius", ["4.125"]),
+            ("ihm_sphere_obj_site", "rmsf", ["0.25"]),
+            ("ihm_starting_model_coord", "B_iso_or_equiv", ["12.5"]),
+        ]
+        for category_name, attribute_name, values in cases:
+            with self.subTest(item="_%s.%s" % (category_name, attribute_name)):
+                self.assertFloatPath(category_name, attribute_name, values)
+
+    def testForcedStringAndIntegerItemsKeepTheirTypes(self):
+        string_column, string_values = self._serialize_column(
+            "audit_conform", "dict_version", ["5.281"]
+        )
+        integer_column, integer_values = self._serialize_column(
+            "atom_site", "id", ["7"]
+        )
+        self.assertEqual(self._encoding_kinds(string_column), ["StringArray"])
+        self.assertEqual(string_values, ["5.281"])
+        self.assertNotIn("StringArray", self._encoding_kinds(integer_column))
+        self.assertEqual(integer_values, [7])
+
+    def testGeneralSmallDecimalColumnsReachFloatPath(self):
+        self.assertFloatPath("task1_test", "one_row", ["1.25"])
+        self.assertFloatPath("task1_test", "two_rows", ["1.25", "2.5"])
+
+    def testLeadingUnderscoreUsesSameCanonicalItemName(self):
+        without_underscore, _ = self._serialize_column(
+            "atom_site_anisotrop", "U[1][1]", ["0.1234"]
+        )
+        with_underscore, _ = self._serialize_column(
+            "_atom_site_anisotrop", "U[1][1]", ["0.1234"]
+        )
+        self.assertEqual(
+            self._encoding_kinds(without_underscore),
+            self._encoding_kinds(with_underscore),
+        )
+
+    def testSentinelsPreserveMaskAndRoundTrip(self):
+        column, decoded_values = self._serialize_column(
+            "task1_test", "masked_float", ["1.5", ".", "?", "2.5", "3.5"]
+        )
+        self.assertIsNotNone(column["mask"])
+        self.assertEqual(decoded_values, [1.5, ".", "?", 2.5, 3.5])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mmcif/tests/testBinaryCifWriterSynthetic.py
+++ b/mmcif/tests/testBinaryCifWriterSynthetic.py
@@ -75,18 +75,6 @@ class BinaryCifWriterSyntheticTests(unittest.TestCase):
         self.assertFloatPath("task1_test", "one_row", ["1.25"])
         self.assertFloatPath("task1_test", "two_rows", ["1.25", "2.5"])
 
-    def testLeadingUnderscoreUsesSameCanonicalItemName(self):
-        without_underscore, _ = self._serialize_column(
-            "atom_site_anisotrop", "U[1][1]", ["0.1234"]
-        )
-        with_underscore, _ = self._serialize_column(
-            "_atom_site_anisotrop", "U[1][1]", ["0.1234"]
-        )
-        self.assertEqual(
-            self._encoding_kinds(without_underscore),
-            self._encoding_kinds(with_underscore),
-        )
-
     def testSentinelsPreserveMaskAndRoundTrip(self):
         column, decoded_values = self._serialize_column(
             "task1_test", "masked_float", ["1.5", ".", "?", "2.5", "3.5"]


### PR DESCRIPTION
This pull request refactors the `BinaryCifWriter` to centralize and modernize the configuration and policy logic for encoding column data types and encoding chains. The changes improve maintainability by moving hard-coded attribute type overrides and encoding chains into configuration modules, and by consistently using canonical item names for policy resolution.

**Centralization and modernization of encoding policy:**

* The logic for forced attribute types (string, integer, float) is moved from hard-coded sets in `BinaryCifWriter.py` to configuration functions and data structures in `mmcif.io.config`, specifically using `get_forced_type` and `canonical_item_name`. The writer now resolves type and encoding policy centrally for each canonical item name. [[1]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL39-R48) [[2]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL209-R224) [[3]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL356-R248) [[4]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL128-R143)

**Consistent use of canonical item names:**

* All methods that require attribute identification now use canonical item names (e.g., `_category.attribute`) for type and encoding policy resolution, ensuring consistent behavior and reducing duplicated logic. [[1]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL128-R143) [[2]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL155-L160) [[3]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL505-R389) [[4]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL893-R793)

**Encoding chain configuration improvements:**

* Default and candidate encoding chains for integers, fixed-point floats, and masks are now imported from configuration, replacing scattered literal lists. This includes `DEFAULT_INTEGER_CHAIN`, `FIXED_POINT_CANDIDATE_INTEGER_CHAINS`, `FLOAT_BYTE_ARRAY_FALLBACK_CHAIN`, and `MASK_ENCODING_CHAIN`. [[1]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL39-R48) [[2]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL796-R669) [[3]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL833-R703) [[4]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL875-R745) [[5]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL893-R793)

**Cleaner and more robust missing value handling:**

* The set of missing value tokens is now imported from configuration (`MISSING_VALUE_TOKENS`), replacing local definitions and ensuring uniform handling of sentinels throughout the module. [[1]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL39-R48) [[2]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL170-R199) [[3]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL725-R614)

**API and internal method signature changes:**

* Several internal methods and encoders have updated signatures to accept canonical item names and configuration-driven parameters, improving clarity and future extensibility. Backwards compatibility is maintained where possible. [[1]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL155-L160) [[2]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL505-R389) [[3]](diffhunk://#diff-4dd0dd722c8febb6fd6919e2835612ccbb4ccbe6817f15e0991a89761c78e70dL893-R793)

These changes make the encoding process more robust, maintainable, and configurable, paving the way for easier updates and improved correctness in the future.