### PR TITLE
BCIF Encoding Improvements: Fixed-Point support and Auto-type detection

### DIFF
--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -678,7 +678,7 @@ class BinaryCifEncoders(object):
     def __encodeBestFixedPointChain(self, colDataList, factor):
         """Try the four FixedPoint integer chains and return the smallest output."""
         candidateEncoderLists = [
-            (("FixedPoint", factor),) + integerChain
+            [("FixedPoint", factor)] + integerChain
             for integerChain in FIXED_POINT_CANDIDATE_INTEGER_CHAINS
         ]
 
@@ -802,7 +802,7 @@ class BinaryCifEncoders(object):
         # factor and post-FixedPoint integer chain.
         if itemConfig is not None and itemConfig.factor is not None:
             factor = itemConfig.factor
-            encoderList = (("FixedPoint", factor),) + itemConfig.integer_chain
+            encoderList = [("FixedPoint", factor)] + itemConfig.integer_chain  # TODO Change "integer_chain" name
             return self.__encodeFixedPointChainOrFallback(
                 maskedColDataList,
                 factor,
@@ -821,7 +821,7 @@ class BinaryCifEncoders(object):
                     return self.__encodeFloatStringFallback(colDataList, colMaskList)
                 return self.encode(maskedColDataList, fallbackEncoderList, "float")
 
-            encoderList = (("FixedPoint", factor),) + itemConfig.integer_chain
+            encoderList = [("FixedPoint", factor)] + itemConfig.integer_chain
             return self.__encodeFixedPointChainOrFallback(
                 maskedColDataList,
                 factor,
@@ -849,7 +849,7 @@ class BinaryCifEncoders(object):
                 return self.encode(maskedColDataList, fallbackEncoderList, "float")
             return encodedColDataList, encodingDictL
 
-        encoderList = (("FixedPoint", factor),) + DEFAULT_FIXED_POINT_INTEGER_CHAIN
+        encoderList = [("FixedPoint", factor)] + DEFAULT_FIXED_POINT_INTEGER_CHAIN
         return self.__encodeFixedPointChainOrFallback(
             maskedColDataList,
             factor,

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -8,7 +8,7 @@
 # - FixedPoint support with IntegerPacking, RunLength, and Delta chains.
 # - Column-specific chains for known high-volume float attributes.
 # - Automatic selection of the smallest general FixedPoint chain.
-# - StringArray fallback for high-precision floats that cannot use FixedPoint.
+# - Optional StringArray fallback for high-precision floats (disabled by default).
 ##
 
 import logging
@@ -220,8 +220,8 @@ class BinaryCifEncoders(object):
 
     # True: known coordinate columns use factor 1000 followed by
     #       Delta -> IntegerPacking -> ByteArray.
-    # False: coordinates skip this hard-coded chain and use the general automatic
-    #        factor detection and four-chain comparison instead.
+    # False: coordinates keep factor 1000 but use the general four-chain
+    #        comparison (Delta/RunLength variants) instead.
     USE_COORDINATE_CHAIN = True
 
 
@@ -640,7 +640,6 @@ class BinaryCifEncoders(object):
         """
         return all(-2147483648 <= int(v) <= 2147483647 for v in data)
 
-    # Check whether the current column is one of the Cartesian coordinate columns
     # Check whether the current column is one of the known Cartesian coordinate columns
     def __isCoordinateItem(self, catName, atName):
         """Return True for a coordinate item that uses the factor-1000 hint."""
@@ -693,7 +692,7 @@ class BinaryCifEncoders(object):
         return self.stringArrayMaskedEncoder(stringColDataList, colMaskList)
 
 
-    # scan the column for needed precision (for other than harcoded columns)
+    # scan the column for needed precision (fallback for -coded columns)
     def __getFloatFixedPointFactor(self, colDataList, catName=None, atName=None):
         """Return the smallest exact-enough FixedPoint factor for a float column."""
         if self.__isCoordinateItem(catName, atName):

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -13,9 +13,8 @@
 #     If supplied, it is used only as a fallback for all-sentinel/empty columns.
 #   - DataCategoryTyped pre-casting is skipped when dictionaryApi is None.
 #   - __encodeColumnData() casts raw string values to int/float before encoding.
-#   - __getAttributeType() uses classify_column() as primary type resolver.
-#   - _FORCE_STRING_ATTRS overrides auto-detection for char-typed attributes
-#     that look numeric (e.g. _audit_conform.dict_version = "5.281").
+#   - __getAttributeType() uses centralized item policy before
+#     bcif_type_detector.classify_column().
 #
 #   15-Jul-2026 ym
 #   - Added FixedPoint float encoding with IntegerPacking, RunLength, and Delta
@@ -221,8 +220,8 @@ class BinaryCifWriter(object):
         """Resolve a column type without changing either legacy path.
 
         Dictionary mode reproduces the original BinaryCifWriter behavior.
-        Auto-detect mode applies forced types first, then scans the values, and
-        optionally uses dictionaryApi only for empty/all-sentinel columns.
+        Auto-detect mode applies configured item types first, then scans the
+        values when no item policy exists.
         """
         if not self.__useAutoDetect:
             cifDataType = self.__dApi.getTypeCode(catName, atName)
@@ -787,8 +786,8 @@ class BinaryCifEncoders(object):
             itemName = canonical_item_name(catName, atName)
         itemConfig = BCIF_CONFIG.get_float_item_config(itemName)
 
-        # Forced float items with a fixed factor always use their configured
-        # factor and encoder chain.
+        # Configured float items with a fixed factor use their configured
+        # factor and post-FixedPoint integer chain.
         if itemConfig is not None and itemConfig.factor is not None:
             factor = itemConfig.factor
             encoderList = (("FixedPoint", factor),) + itemConfig.integer_chain

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -36,7 +36,17 @@ import warnings
 from mmcif.api.DataCategoryTyped import DataCategoryTyped, DataCategoryHints
 from mmcif.api.PdbxContainers import CifName
 from mmcif.io.BinaryCifReader import BinaryCifDecoders
-from mmcif.io.config import BCIF_CONFIG, canonical_item_name, get_forced_type
+from mmcif.io.config import (
+    BCIF_CONFIG,
+    DEFAULT_FIXED_POINT_INTEGER_CHAIN,
+    DEFAULT_INTEGER_CHAIN,
+    FIXED_POINT_CANDIDATE_INTEGER_CHAINS,
+    FLOAT_BYTE_ARRAY_FALLBACK_CHAIN,
+    MASK_ENCODING_CHAIN,
+    MISSING_VALUE_TOKENS,
+    canonical_item_name,
+    get_forced_type,
+)
 
 from mmcif.io.bcif_type_detector import classify_column
 
@@ -159,7 +169,6 @@ class BinaryCifWriter(object):
         colMaskDict = None  # Use None when no mask and not {} - per Mol* implementation
         enc = BinaryCifEncoders(defaultStringEncoding=self.__defaultStringEncoding, storeStringsAsBytes=self.__storeStringsAsBytes, useFloat64=self.__useFloat64)
         #
-        maskEncoderList = ["RunLength", "ByteArray"]
         typeEncoderD = {"string": "StringArrayMasked", "integer": "IntArrayMasked", "float": "FloatArrayMasked"}
         colMaskList = enc.getMask(colDataList)
 
@@ -169,16 +178,15 @@ class BinaryCifWriter(object):
         # Cast here using the dataType already determined by __getAttributeType.
         # Sentinel values (".", "?", None) are left untouched so getMask()
         # results remain valid.
-        _SENTINELS = {".", "?"}
         if self.__useAutoDetect and dataType == "integer":
             colDataList = [
-                v if (v is None or v in _SENTINELS)
+                v if (v is None or v in MISSING_VALUE_TOKENS)
                 else (v if isinstance(v, int) else int(v))
                 for v in colDataList
             ]
         elif self.__useAutoDetect and dataType == "float":
             colDataList = [
-                v if (v is None or v in _SENTINELS)
+                v if (v is None or v in MISSING_VALUE_TOKENS)
                 else (v if isinstance(v, float) else float(v))
                 for v in colDataList
             ]
@@ -189,7 +197,7 @@ class BinaryCifWriter(object):
         if colMaskList:
             # Mol* indicates that masks should be encoded as if uint_8
             colMaskListTyped = TypedArray(colMaskList, "unsigned_integer_8")
-            maskEncoded, maskEncodingDictL = enc.encode(colMaskListTyped, maskEncoderList, "integer")
+            maskEncoded, maskEncodingDictL = enc.encode(colMaskListTyped, MASK_ENCODING_CHAIN, "integer")
             colMaskDict = {self.__toBytes("data"): maskEncoded.data, self.__toBytes("encoding"): maskEncodingDictL}
         return colMaskDict, colDataEncoded, colDataEncodingDictL
 
@@ -292,7 +300,6 @@ class BinaryCifEncoders(object):
             storeStringsAsBytes (bool, optional): strings are stored as bytes. Defaults to True.
             useFloat64 (bool, optional): store floats in 64 bit precision. Defaults to True.
         """
-        self.__unknown = [".", "?"]
         self.__defaultStringEncoding = defaultStringEncoding
         self.__storeStringsAsBytes = storeStringsAsBytes
         self.__useFloat64 = useFloat64
@@ -605,7 +612,7 @@ class BinaryCifEncoders(object):
                 continue
 
             valueString = str(val).strip()
-            if valueString in self.__unknown:
+            if valueString in MISSING_VALUE_TOKENS:
                 continue
 
             if "e" in valueString.lower():
@@ -659,10 +666,8 @@ class BinaryCifEncoders(object):
     def __encodeBestFixedPointChain(self, colDataList, factor):
         """Try the four FixedPoint integer chains and return the smallest output."""
         candidateEncoderLists = [
-            [("FixedPoint", factor), "IntegerPacking", "ByteArray"],
-            [("FixedPoint", factor), "RunLength", "IntegerPacking", "ByteArray"],
-            [("FixedPoint", factor), "Delta", "IntegerPacking", "ByteArray"],
-            [("FixedPoint", factor), "Delta", "RunLength", "IntegerPacking", "ByteArray"],
+            (("FixedPoint", factor),) + integerChain
+            for integerChain in FIXED_POINT_CANDIDATE_INTEGER_CHAINS
         ]
 
         bestSize = None
@@ -696,7 +701,7 @@ class BinaryCifEncoders(object):
         Returns:
             (list, list): encoded data column, list of encoding instructions
         """
-        integerEncoderList = ["Delta", "RunLength", "IntegerPacking", "ByteArray"]
+        integerEncoderList = DEFAULT_INTEGER_CHAIN
         uniqStringIndex = {}  # keys are substrings, values indices
         uniqStringList = []
         indexList = []
@@ -738,7 +743,7 @@ class BinaryCifEncoders(object):
         Returns:
             (list, list): encoded data column, list of encoding instructions
         """
-        integerEncoderList = ["Delta", "RunLength", "IntegerPacking", "ByteArray"]
+        integerEncoderList = DEFAULT_INTEGER_CHAIN
 
         if colMaskList:
             # Mol* and BinaryCif specification https://github.com/molstar/BinaryCIF/blob/master/encoding.md
@@ -756,19 +761,19 @@ class BinaryCifEncoders(object):
             numericValues = [float(v) for v in colDataList]
 
             if not all(math.isfinite(v) for v in numericValues):
-                return self.encode(colDataList, ["ByteArray"], "float")
+                return self.encode(colDataList, FLOAT_BYTE_ARRAY_FALLBACK_CHAIN, "float")
 
             fixedPointValues = [
                 self.__roundLikeMolStar(v * factor)
                 for v in numericValues
             ]
             if not self.__fitsInt32(fixedPointValues):
-                return self.encode(colDataList, ["ByteArray"], "float")
+                return self.encode(colDataList, FLOAT_BYTE_ARRAY_FALLBACK_CHAIN, "float")
 
             return self.encode(colDataList, encoderList, "float")
         except Exception as e:
             logger.debug("Falling back from the fixed float chain for %s: %s", itemName, str(e))
-            return self.encode(colDataList, ["ByteArray"], "float")
+            return self.encode(colDataList, FLOAT_BYTE_ARRAY_FALLBACK_CHAIN, "float")
 
     def floatArrayMaskedEncoder(self, colDataList, colMaskList, catName=None, atName=None, itemName=None):
         """Encode a float column, preserving its incompleteness mask."""
@@ -777,7 +782,7 @@ class BinaryCifEncoders(object):
         else:
             maskedColDataList = colDataList
 
-        fallbackEncoderList = ["ByteArray"]
+        fallbackEncoderList = FLOAT_BYTE_ARRAY_FALLBACK_CHAIN
         if itemName is None:
             itemName = canonical_item_name(catName, atName)
         itemConfig = BCIF_CONFIG.get_float_item_config(itemName)
@@ -786,7 +791,7 @@ class BinaryCifEncoders(object):
         # factor and encoder chain.
         if itemConfig is not None and itemConfig.factor is not None:
             factor = itemConfig.factor
-            encoderList = BCIF_CONFIG.get_float_encoder_list(itemName)
+            encoderList = (("FixedPoint", factor),) + itemConfig.integer_chain
             return self.__encodeFixedPointChainOrFallback(
                 maskedColDataList,
                 factor,
@@ -805,10 +810,7 @@ class BinaryCifEncoders(object):
                     return self.__encodeFloatStringFallback(colDataList, colMaskList)
                 return self.encode(maskedColDataList, fallbackEncoderList, "float")
 
-            encoderList = [
-                ("FixedPoint", factor),
-                *itemConfig.encoderList,
-            ]
+            encoderList = (("FixedPoint", factor),) + itemConfig.integer_chain
             return self.__encodeFixedPointChainOrFallback(
                 maskedColDataList,
                 factor,
@@ -836,13 +838,7 @@ class BinaryCifEncoders(object):
                 return self.encode(maskedColDataList, fallbackEncoderList, "float")
             return encodedColDataList, encodingDictL
 
-        encoderList = [
-            ("FixedPoint", factor),
-            "Delta",
-            "RunLength",
-            "IntegerPacking",
-            "ByteArray",
-        ]
+        encoderList = (("FixedPoint", factor),) + DEFAULT_FIXED_POINT_INTEGER_CHAIN
         return self.__encodeFixedPointChainOrFallback(
             maskedColDataList,
             factor,
@@ -862,7 +858,7 @@ class BinaryCifEncoders(object):
         """
         mask = None
         for ii, colVal in enumerate(colDataList):
-            if colVal is not None and colVal not in self.__unknown:
+            if colVal is not None and colVal not in MISSING_VALUE_TOKENS:
                 continue
             if not mask:
                 mask = [0] * len(colDataList)

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -93,9 +93,6 @@ class BinaryCifWriter(object):
             containerList (list): list of DataContainer objects
         """
 
-        dataTypeList = []
-        dataTypeList.append("New Run\n")
-
         try:
             blocks = []
             for container in containerList:
@@ -119,9 +116,6 @@ class BinaryCifWriter(object):
                         colDataList = cObj.getColumn(ii)
                         dataType = self.__getAttributeType(cObj, atName, colDataList) if not self.__useStringTypes else "string"
 
-                        fullAttrName = "_%s.%s" % (catName, atName)
-                        dataTypeList.append(fullAttrName + ": " + dataType)
-
                         logger.debug("catName %r atName %r dataType %r", catName, atName, dataType)
                         colMaskDict, encodedColDataList, encodingDictL = self.__encodeColumnData(colDataList, dataType)
                         cols.append(
@@ -140,10 +134,6 @@ class BinaryCifWriter(object):
             }
             with open(filePath, "wb") as ofh:
                 msgpack.pack(data, ofh)
-            
-            with open("dataType.txt" if self.__useAutoDetect else "dataType_dict.txt", "a") as f:
-                for item in dataTypeList:
-                    f.write(item + "\n")
             
             return True
         except Exception as e:
@@ -243,7 +233,71 @@ class BinaryCifWriter(object):
         "atom_site.cartn_y",
         "atom_site.cartn_z",
         "atom_site.occupancy",
-        "atom_site.b_iso_or_equiv"
+        "atom_site.b_iso_or_equiv",
+ 
+        # PDBx/mmCIF chemical component Cartesian coordinates
+        "chem_comp_atom.model_cartn_x",
+        "chem_comp_atom.model_cartn_y",
+        "chem_comp_atom.model_cartn_z",
+        "chem_comp_atom.pdbx_model_cartn_x_ideal",
+        "chem_comp_atom.pdbx_model_cartn_y_ideal",
+        "chem_comp_atom.pdbx_model_cartn_z_ideal",
+ 
+        # PDBx/mmCIF phasing-site Cartesian coordinates
+        "phasing_mir_der_site.cartn_x",
+        "phasing_mir_der_site.cartn_y",
+        "phasing_mir_der_site.cartn_z",
+        "pdbx_phasing_mad_set_site.cartn_x",
+        "pdbx_phasing_mad_set_site.cartn_y",
+        "pdbx_phasing_mad_set_site.cartn_z",
+ 
+        # PDBx/mmCIF solvent atom-site mapping coordinates
+        "pdbx_solvent_atom_site_mapping.cartn_x",
+        "pdbx_solvent_atom_site_mapping.cartn_y",
+        "pdbx_solvent_atom_site_mapping.cartn_z",
+        "pdbx_solvent_atom_site_mapping.pre_cartn_x",
+        "pdbx_solvent_atom_site_mapping.pre_cartn_y",
+        "pdbx_solvent_atom_site_mapping.pre_cartn_z",
+ 
+        # CSM / ModelCIF template Cartesian coordinates
+        "ma_template_coord.cartn_x",
+        "ma_template_coord.cartn_y",
+        "ma_template_coord.cartn_z",
+ 
+        # IHM starting-model atomic Cartesian coordinates
+        "ihm_starting_model_coord.cartn_x",
+        "ihm_starting_model_coord.cartn_y",
+        "ihm_starting_model_coord.cartn_z",
+ 
+        # IHM coarse sphere Cartesian coordinates
+        "ihm_sphere_obj_site.cartn_x",
+        "ihm_sphere_obj_site.cartn_y",
+        "ihm_sphere_obj_site.cartn_z",
+ 
+        # IHM Gaussian-object mean Cartesian coordinates
+        "ihm_gaussian_obj_site.mean_cartn_x",
+        "ihm_gaussian_obj_site.mean_cartn_y",
+        "ihm_gaussian_obj_site.mean_cartn_z",
+ 
+        # IHM Gaussian-ensemble mean Cartesian coordinates
+        "ihm_gaussian_obj_ensemble.mean_cartn_x",
+        "ihm_gaussian_obj_ensemble.mean_cartn_y",
+        "ihm_gaussian_obj_ensemble.mean_cartn_z",
+ 
+        # IHM pseudo-site Cartesian coordinates
+        "ihm_pseudo_site.cartn_x",
+        "ihm_pseudo_site.cartn_y",
+        "ihm_pseudo_site.cartn_z",
+ 
+        # FLR/FPS mean probe position coordinates
+        "flr_fps_mean_probe_position.mpp_xcoord",
+        "flr_fps_mean_probe_position.mpp_ycoord",
+        "flr_fps_mean_probe_position.mpp_zcoord",
+ 
+        # FLR/FPS MPP atom position coordinates
+        "flr_fps_mpp_atom_position.xcoord",
+        "flr_fps_mpp_atom_position.ycoord",
+        "flr_fps_mpp_atom_position.zcoord",
     })
     
     def __getForcedAttributeType(self, dObj, atName):

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -951,12 +951,13 @@ class BinaryCifEncoders(object):
 
         # General floats: auto-detect a safe FixedPoint factor.
         factor = self.__getFloatFixedPointFactor(maskedColDataList)
-        if factor is None:
+        if factor is None:  # no suitable FixedPoint factor was found; use a fallback encoding (string or bytearray)
             if (
                 BCIF_CONFIG.USE_STRING_FLOAT_FALLBACK
                 and self.__shouldUseStringFallbackForFloat(maskedColDataList)
             ):
                 return self.__encodeFloatStringFallback(colDataList, colMaskList)
+            # encode as byte array
             return self.encode(maskedColDataList, fallbackEncoderList, "float")
 
         if BCIF_CONFIG.COMPARE_ALL_FIXED_POINT_CHAINS:

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -1,16 +1,20 @@
 ##
-# File: BinaryCifWrite.py
+# File: BinaryCifWriter.py
 # Date: 15-May-2021  jdw
 #
-#  Write methods and encoders for binary CIF serialization.
+# Write methods and encoders for BinaryCIF serialization.
 #
-#  Updates:
-#
+# Float encoding updates:
+# - FixedPoint support with IntegerPacking, RunLength, and Delta chains.
+# - Column-specific chains for known high-volume float attributes.
+# - Automatic selection of the smallest general FixedPoint chain.
+# - StringArray fallback for high-precision floats that cannot use FixedPoint.
 ##
 
 import logging
 import struct
 import msgpack
+import math
 import warnings
 
 from mmcif.api.DataCategoryTyped import DataCategoryTyped, DataCategoryHints
@@ -87,7 +91,8 @@ class BinaryCifWriter(object):
                         colDataList = cObj.getColumn(ii)
                         dataType = self.__getAttributeType(cObj, atName) if not self.__useStringTypes else "string"
                         logger.debug("catName %r atName %r dataType %r", catName, atName, dataType)
-                        colMaskDict, encodedColDataList, encodingDictL = self.__encodeColumnData(colDataList, dataType)
+                        # Pass category/item names so float columns can use coordinate-specific hints
+                        colMaskDict, encodedColDataList, encodingDictL = self.__encodeColumnData(colDataList, dataType, catName, atName)
                         cols.append(
                             {
                                 self.__toBytes("name"): self.__toBytes(atName),
@@ -109,7 +114,8 @@ class BinaryCifWriter(object):
             logger.exception("Failing with %s", str(e))
         return False
 
-    def __encodeColumnData(self, colDataList, dataType):
+    # Accept category/item names so encoder selection can use column-specific hints
+    def __encodeColumnData(self, colDataList, dataType, catName=None, atName=None):
         colMaskDict = None  # Use None when no mask and not {} - per Mol* implementation
         enc = BinaryCifEncoders(defaultStringEncoding=self.__defaultStringEncoding, storeStringsAsBytes=self.__storeStringsAsBytes, useFloat64=self.__useFloat64)
         #
@@ -117,7 +123,8 @@ class BinaryCifWriter(object):
         typeEncoderD = {"string": "StringArrayMasked", "integer": "IntArrayMasked", "float": "FloatArrayMasked"}
         colMaskList = enc.getMask(colDataList)
         dataEncType = typeEncoderD[dataType]
-        colDataEncoded, colDataEncodingDictL = enc.encodeWithMask(colDataList, colMaskList, dataEncType)
+        # Forward category/item names to the masked encoder
+        colDataEncoded, colDataEncodingDictL = enc.encodeWithMask(colDataList, colMaskList, dataEncType, catName=catName, atName=atName)
         if colMaskList:
             # Mol* indicates that masks should be encoded as if uint_8
             colMaskListTyped = TypedArray(colMaskList, "unsigned_integer_8")
@@ -197,6 +204,140 @@ class BinaryCifEncoders(object):
 
     """
 
+
+    # Float encoding feature switches
+    #
+    # The five individual switches below only apply when the switch is
+    # True. Disabling an individual hard-code does not force ByteArray; it sends
+    # that column through the general automatic FixedPoint chain selection.
+
+
+    # True: enable the new FixedPoint-based float encoding logic and all enabled
+    #       specialized paths below.
+    # False: bypass every float optimization below and encode all floats directly
+    #        with the original float ByteArray behavior.
+    USE_FIXED_POINT_FLOAT_ENCODING = True
+
+    # True: known coordinate columns use factor 1000 followed by
+    #       Delta -> IntegerPacking -> ByteArray.
+    # False: coordinates skip this hard-coded chain and use the general automatic
+    #        factor detection and four-chain comparison instead.
+    USE_COORDINATE_CHAIN = True
+
+
+    # True: the six _atom_site_anisotrop U columns use factor 10000 followed by
+    #       Delta -> IntegerPacking -> ByteArray.
+    # False: those columns skip this hard-code and use the general float path.
+    USE_ANISOTROP_U_CHAIN = True
+
+
+    # True: _ihm_sphere_obj_site.object_radius uses factor 1000 followed by
+    #       IntegerPacking -> ByteArray, without Delta or RunLength.
+    # False: object_radius skips this hard-code and uses the general float path.
+    USE_OBJECT_RADIUS_CHAIN = True
+
+
+    # True: occupancy, B_iso_or_equiv, rmsf, and starting-model B_iso_or_equiv
+    #       use an automatically detected factor followed by
+    #       RunLength -> IntegerPacking -> ByteArray.
+    # False: those four attributes skip the RunLength hint and use the general
+    #        automatic factor detection and four-chain comparison.
+    USE_RUN_LENGTH_FLOAT_HINTS = True
+
+
+    # True: when no safe FixedPoint factor is found and a column contains values
+    #       with 5 or more decimal places, encode it as StringArrayMasked.
+    # False: those high-precision fallback columns use float ByteArray instead.
+    USE_STRING_FLOAT_FALLBACK = False
+
+    COORDINATE_FIXED_POINT_FACTOR = 1000
+
+
+    ANISOTROP_U_FIXED_POINT_FACTOR = 10000
+    OBJECT_RADIUS_FIXED_POINT_FACTOR = 1000
+    MAX_FIXED_POINT_DECIMAL_PLACES = 4
+    STRING_FALLBACK_MIN_DECIMAL_PLACES = 5
+    FIXED_POINT_TOLERANCE = 1.0e-6
+
+    COORDINATE_ITEMS = {
+        # PDB / standard model coordinates
+        "_atom_site.Cartn_x",
+        "_atom_site.Cartn_y",
+        "_atom_site.Cartn_z",
+
+        # PDBx/mmCIF chemical component coordinates
+        "_chem_comp_atom.model_Cartn_x",
+        "_chem_comp_atom.model_Cartn_y",
+        "_chem_comp_atom.model_Cartn_z",
+        "_chem_comp_atom.pdbx_model_Cartn_x_ideal",
+        "_chem_comp_atom.pdbx_model_Cartn_y_ideal",
+        "_chem_comp_atom.pdbx_model_Cartn_z_ideal",
+
+        # PDBx/mmCIF phasing-site coordinates
+        "_phasing_MIR_der_site.Cartn_x",
+        "_phasing_MIR_der_site.Cartn_y",
+        "_phasing_MIR_der_site.Cartn_z",
+        "_pdbx_phasing_MAD_set_site.Cartn_x",
+        "_pdbx_phasing_MAD_set_site.Cartn_y",
+        "_pdbx_phasing_MAD_set_site.Cartn_z",
+
+        # PDBx/mmCIF solvent atom-site mapping coordinates
+        "_pdbx_solvent_atom_site_mapping.Cartn_x",
+        "_pdbx_solvent_atom_site_mapping.Cartn_y",
+        "_pdbx_solvent_atom_site_mapping.Cartn_z",
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_x",
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_y",
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_z",
+
+        # ModelCIF / CSM template coordinates
+        "_ma_template_coord.Cartn_x",
+        "_ma_template_coord.Cartn_y",
+        "_ma_template_coord.Cartn_z",
+
+        # IHM coordinates
+        "_ihm_starting_model_coord.Cartn_x",
+        "_ihm_starting_model_coord.Cartn_y",
+        "_ihm_starting_model_coord.Cartn_z",
+        "_ihm_sphere_obj_site.Cartn_x",
+        "_ihm_sphere_obj_site.Cartn_y",
+        "_ihm_sphere_obj_site.Cartn_z",
+        "_ihm_gaussian_obj_site.mean_Cartn_x",
+        "_ihm_gaussian_obj_site.mean_Cartn_y",
+        "_ihm_gaussian_obj_site.mean_Cartn_z",
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_x",
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_y",
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_z",
+        "_ihm_pseudo_site.Cartn_x",
+        "_ihm_pseudo_site.Cartn_y",
+        "_ihm_pseudo_site.Cartn_z",
+
+        # FLR / FPS coordinates
+        "_flr_FPS_mean_probe_position.mpp_xcoord",
+        "_flr_FPS_mean_probe_position.mpp_ycoord",
+        "_flr_FPS_mean_probe_position.mpp_zcoord",
+        "_flr_FPS_MPP_atom_position.xcoord",
+        "_flr_FPS_MPP_atom_position.ycoord",
+        "_flr_FPS_MPP_atom_position.zcoord",
+    }
+
+    ANISOTROP_U_ITEMS = {
+        "_atom_site_anisotrop.U[1][1]",
+        "_atom_site_anisotrop.U[1][2]",
+        "_atom_site_anisotrop.U[1][3]",
+        "_atom_site_anisotrop.U[2][2]",
+        "_atom_site_anisotrop.U[2][3]",
+        "_atom_site_anisotrop.U[3][3]",
+    }
+
+    RUN_LENGTH_FLOAT_ITEMS = {
+        "_atom_site.occupancy",
+        "_atom_site.B_iso_or_equiv",
+        "_ihm_sphere_obj_site.rmsf",
+        "_ihm_starting_model_coord.B_iso_or_equiv",
+    }
+
+    OBJECT_RADIUS_ITEM = "_ihm_sphere_obj_site.object_radius"
+
     def __init__(self, defaultStringEncoding="utf-8", storeStringsAsBytes=True, useFloat64=False):
         """Instantiate the binary CIF encoder class.
 
@@ -237,9 +378,20 @@ class BinaryCifEncoders(object):
             legacy = True
 
         encDict = None
+        # Track data type changes as chained encoders transform the array
+        currentDataType = dataType
         for encType in encodingTypeList:
+            encArg = None
+            # Allow encoders with parameters, e.g. ("FixedPoint", factor)
+            if isinstance(encType, tuple):
+                encType, encArg = encType
+
             if encType == "ByteArray":
-                colDataList, encDict = self.byteArrayEncoderTyped(colDataList, dataType)
+                colDataList, encDict = self.byteArrayEncoderTyped(colDataList, currentDataType)
+            # FixedPoint converts float values into integer_32 values
+            elif encType == "FixedPoint":
+                colDataList, encDict = self.fixedPointEncoderTyped(colDataList, encArg)
+                currentDataType = "integer"
             elif encType == "Delta":
                 colDataList, encDict = self.deltaEncoderTyped(colDataList)
             elif encType == "RunLength":
@@ -254,7 +406,8 @@ class BinaryCifEncoders(object):
             return colDataList.data, encodingDictL
         return colDataList, encodingDictL
 
-    def encodeWithMask(self, colDataList, colMaskList, encodingType):
+    # Accept category/item names for float-column encoding decisions
+    def encodeWithMask(self, colDataList, colMaskList, encodingType, catName=None, atName=None):
         """Encode the data using the input mask and encoding type returning encoded data and encoding instructions.
 
         Args:
@@ -271,8 +424,9 @@ class BinaryCifEncoders(object):
             encodedColDataList, encodingDictL = self.stringArrayMaskedEncoder(colDataList, colMaskList)
         elif encodingType == "IntArrayMasked":
             encodedColDataList, encodingDictL = self.intArrayMaskedEncoder(colDataList, colMaskList)
+        # Pass category/item names only to the float encoder
         elif encodingType == "FloatArrayMasked":
-            encodedColDataList, encodingDictL = self.floatArrayMaskedEncoder(colDataList, colMaskList)
+            encodedColDataList, encodingDictL = self.floatArrayMaskedEncoder(colDataList, colMaskList, catName=catName, atName=atName)
         else:
             logger.info("unsupported masked encoding %r", encodingType)
         return encodedColDataList, encodingDictL
@@ -434,6 +588,170 @@ class BinaryCifEncoders(object):
             encodedTypedColDataList = TypedArray(encodedColDataList, "integer_32")
             return encodedTypedColDataList, encodingD
 
+    # Convert scaled float values into integer_32 values for later integer encoders
+    def fixedPointEncoderTyped(self, colTypedDataList, factor):
+        """Encode a float array as a 32-bit integer array using FixedPoint.
+
+        Args:
+            colTypedDataList (TypedArray): list of float data (float_32 or float_64)
+            factor (int): multiplier used to convert float values to integers
+
+        Returns:
+            TypedArray: fixed-point encoded integer list (integer_32)
+            dict: binary CIF FixedPoint encoding instructions
+        """
+        if colTypedDataList.dtype and colTypedDataList.dtype not in ["float_32", "float_64"]:
+            raise TypeError("Only float arrays can be encoded with FixedPoint: %s" % colTypedDataList.dtype)
+
+        srcType = colTypedDataList.dtype or ("float_64" if self.__useFloat64 else "float_32")
+        encodedColDataList = [self.__roundLikeMolStar(float(v) * factor) for v in colTypedDataList.data]
+
+        if not self.__fitsInt32(encodedColDataList):
+            raise TypeError("FixedPoint output does not fit in integer_32")
+
+        encodingD = {
+            self.__toBytes("kind"): self.__toBytes("FixedPoint"),
+            self.__toBytes("factor"): factor,
+            self.__toBytes("srcType"): self.__bCifTypeCodeD[srcType],
+        }
+        return TypedArray(encodedColDataList, "integer_32"), encodingD
+
+    # Match Mol* JavaScript rounding behavior during FixedPoint conversion
+    def __roundLikeMolStar(self, value):
+        """Round a float value using JavaScript Math.round-like behavior.
+
+        Args:
+            value (float): input float value
+
+        Returns:
+            int: rounded integer value
+        """
+        return int(math.floor(value + 0.5))
+
+    # Ensure FixedPoint output can safely be stored as integer_32
+    def __fitsInt32(self, data):
+        """Check whether all input values fit in a signed 32-bit integer array.
+
+        Args:
+            data (list): list of integer values
+
+        Returns:
+            bool: True if all values fit in signed 32-bit integer range, otherwise False
+        """
+        return all(-2147483648 <= int(v) <= 2147483647 for v in data)
+
+    # Check whether the current column is one of the Cartesian coordinate columns
+    # Check whether the current column is one of the known Cartesian coordinate columns
+    def __isCoordinateItem(self, catName, atName):
+        """Return True for a coordinate item that uses the factor-1000 hint."""
+        return self.__getItemName(catName, atName) in self.COORDINATE_ITEMS
+
+    def __getItemName(self, catName, atName):
+        """Return normalized _category.attribute item name."""
+        if catName is None or atName is None:
+            return ""
+
+        cat = str(catName)
+        if cat.startswith("_"):
+            cat = cat[1:]
+
+        return "_%s.%s" % (cat, atName)
+
+    def __isAnisotropUItem(self, catName, atName):
+        """Return True for an anisotropic displacement U matrix item."""
+        return self.__getItemName(catName, atName) in self.ANISOTROP_U_ITEMS
+
+    def __shouldUseStringFallbackForFloat(self, colDataList):
+        """Return True when the column requires high-precision float fallback."""
+        for val in colDataList:
+            if val is None:
+                continue
+
+            valueString = str(val).strip()
+            if valueString in self.__unknown:
+                continue
+
+            if "e" in valueString.lower():
+                decimalPlaces = 99
+            elif "." in valueString:
+                decimalPlaces = len(valueString.split(".", 1)[1].rstrip("0"))
+            else:
+                decimalPlaces = 0
+
+            if decimalPlaces >= self.STRING_FALLBACK_MIN_DECIMAL_PLACES:
+                return True
+
+        return False
+
+    def __encodeFloatStringFallback(self, colDataList, colMaskList):
+        """Encode a float fallback column as StringArrayMasked."""
+        if colMaskList:
+            stringColDataList = ["0.0" if m else str(d) for m, d in zip(colMaskList, colDataList)]
+        else:
+            stringColDataList = [str(d) for d in colDataList]
+
+        return self.stringArrayMaskedEncoder(stringColDataList, colMaskList)
+
+
+    # scan the column for needed precision (for other than harcoded columns)
+    def __getFloatFixedPointFactor(self, colDataList, catName=None, atName=None):
+        """Return the smallest exact-enough FixedPoint factor for a float column."""
+        if self.__isCoordinateItem(catName, atName):
+            return self.COORDINATE_FIXED_POINT_FACTOR
+
+        mantissaDigits = 0
+        for val in colDataList:
+            value = float(val)
+            if not math.isfinite(value):
+                return None
+
+            foundDigits = None
+            factor = 1
+            for digits in range(self.MAX_FIXED_POINT_DECIMAL_PLACES + 1):
+                scaledValue = factor * value
+                if abs(round(scaledValue) - scaledValue) <= self.FIXED_POINT_TOLERANCE:
+                    foundDigits = digits
+                    break
+                factor *= 10
+
+            if foundDigits is None:
+                return None
+
+            mantissaDigits = max(mantissaDigits, foundDigits)
+
+        return 10 ** mantissaDigits
+
+    # Try each FixedPoint integer chain and keep the smallest byte output
+    def __encodeBestFixedPointChain(self, colDataList, factor):
+        """Try the four FixedPoint integer chains and return the smallest output."""
+        candidateEncoderLists = [
+            [("FixedPoint", factor), "IntegerPacking", "ByteArray"],
+            [("FixedPoint", factor), "RunLength", "IntegerPacking", "ByteArray"],
+            [("FixedPoint", factor), "Delta", "IntegerPacking", "ByteArray"],
+            [("FixedPoint", factor), "Delta", "RunLength", "IntegerPacking", "ByteArray"],
+        ]
+
+        best = None
+        for encoderList in candidateEncoderLists:
+            try:
+                encodedColDataList, encodingDictL = self.encode(list(colDataList), encoderList, "float")
+                encodedData = encodedColDataList.data if isinstance(encodedColDataList, TypedArray) else encodedColDataList
+                size = len(encodedData)
+
+                if best is None or size < best[0]:
+                    best = (size, encodedColDataList, encodingDictL)
+            except Exception as e:
+                logger.debug("Skipping float encoder chain %r: %s", encoderList, str(e))
+
+        if best is None:
+            return None, None
+
+        return best[1], best[2]
+
+
+
+
+
     def stringArrayMaskedEncoder(self, colDataList, colMaskList):
         """Encode the input data column (string) along with the incompleteness mask.
 
@@ -497,24 +815,86 @@ class BinaryCifEncoders(object):
         encodedColDataList, encodingDictL = self.encode(maskedColDataList, integerEncoderList, "integer")
         return encodedColDataList, encodingDictL
 
-    def floatArrayMaskedEncoder(self, colDataList, colMaskList):
-        """Encode the input data column (float) along with the incompleteness mask.
+    # Encode float columns with FixedPoint chains instead of ByteArray-only when safe
+    def __encodeFixedPointChainOrFallback(self, colDataList, factor, encoderList, itemName):
+        """Run one FixedPoint chain, falling back to float ByteArray when unsafe."""
+        try:
+            numericValues = [float(v) for v in colDataList]
 
-        Args:
-            colDataList (list): input data column (string)
-            colMaskList (list): incompleteness mask
+            if not all(math.isfinite(v) for v in numericValues):
+                return self.encode(colDataList, ["ByteArray"], "float")
 
-        Returns:
-            (list, list): encoded data column, list of encoding instructions
-        """
-        floatEncoderList = ["ByteArray"]
+            fixedPointValues = [
+                self.__roundLikeMolStar(v * factor)
+                for v in numericValues
+            ]
+            if not self.__fitsInt32(fixedPointValues):
+                return self.encode(colDataList, ["ByteArray"], "float")
 
+            return self.encode(colDataList, encoderList, "float")
+        except Exception as e:
+            logger.debug("Falling back from the fixed float chain for %s: %s", itemName, str(e))
+            return self.encode(colDataList, ["ByteArray"], "float")
+
+    def floatArrayMaskedEncoder(self, colDataList, colMaskList, catName=None, atName=None):
+        """Encode a float column, preserving its incompleteness mask."""
         if colMaskList:
             maskedColDataList = [0.0 if m else d for m, d in zip(colMaskList, colDataList)]
         else:
             maskedColDataList = colDataList
-        encodedColDataList, encodingDictL = self.encode(maskedColDataList, floatEncoderList, "float")
+
+        fallbackEncoderList = ["ByteArray"]
+        if not self.USE_FIXED_POINT_FLOAT_ENCODING:
+            return self.encode(maskedColDataList, fallbackEncoderList, "float")
+
+        itemName = self.__getItemName(catName, atName)
+
+        # Known coordinate columns: factor 1000 + Delta.
+        if self.USE_COORDINATE_CHAIN and self.__isCoordinateItem(catName, atName):
+            factor = self.COORDINATE_FIXED_POINT_FACTOR
+            encoderList = [("FixedPoint", factor), "Delta", "IntegerPacking", "ByteArray"]
+            return self.__encodeFixedPointChainOrFallback(maskedColDataList, factor, encoderList, itemName)
+
+        # Anisotropic U columns: factor 10000 + Delta.
+        if self.USE_ANISOTROP_U_CHAIN and self.__isAnisotropUItem(catName, atName):
+            factor = self.ANISOTROP_U_FIXED_POINT_FACTOR
+            encoderList = [("FixedPoint", factor), "Delta", "IntegerPacking", "ByteArray"]
+            return self.__encodeFixedPointChainOrFallback(maskedColDataList, factor, encoderList, itemName)
+
+        # IHM sphere radius: factor 1000 without Delta or RunLength.
+        if self.USE_OBJECT_RADIUS_CHAIN and itemName == self.OBJECT_RADIUS_ITEM:
+            factor = self.OBJECT_RADIUS_FIXED_POINT_FACTOR
+            encoderList = [("FixedPoint", factor), "IntegerPacking", "ByteArray"]
+            return self.__encodeFixedPointChainOrFallback(maskedColDataList, factor, encoderList, itemName)
+
+        # Repeated high-volume float items: automatic factor + RunLength.
+        if self.USE_RUN_LENGTH_FLOAT_HINTS and itemName in self.RUN_LENGTH_FLOAT_ITEMS:
+            factor = self.__getFloatFixedPointFactor(maskedColDataList, catName=catName, atName=atName)
+            if factor is None:
+                if self.USE_STRING_FLOAT_FALLBACK and self.__shouldUseStringFallbackForFloat(maskedColDataList):
+                    return self.__encodeFloatStringFallback(colDataList, colMaskList)
+                return self.encode(maskedColDataList, fallbackEncoderList, "float")
+
+            encoderList = [("FixedPoint", factor), "RunLength", "IntegerPacking", "ByteArray"]
+            return self.__encodeFixedPointChainOrFallback(maskedColDataList, factor, encoderList, itemName)
+
+        # General floats: detect a factor and choose the smallest of four chains.
+        factor = self.__getFloatFixedPointFactor(maskedColDataList, catName=catName, atName=atName)
+        if factor is None:
+            if self.USE_STRING_FLOAT_FALLBACK and self.__shouldUseStringFallbackForFloat(maskedColDataList):
+                return self.__encodeFloatStringFallback(colDataList, colMaskList)
+            return self.encode(maskedColDataList, fallbackEncoderList, "float")
+
+        fixedPointValues = [self.__roundLikeMolStar(float(v) * factor) for v in maskedColDataList]
+        if not self.__fitsInt32(fixedPointValues):
+            return self.encode(maskedColDataList, fallbackEncoderList, "float")
+
+        encodedColDataList, encodingDictL = self.__encodeBestFixedPointChain(maskedColDataList, factor)
+        if encodedColDataList is None:
+            return self.encode(maskedColDataList, fallbackEncoderList, "float")
+
         return encodedColDataList, encodingDictL
+
 
     def getMask(self, colDataList):
         """Create an incompleteness mask list identifying missing/omitted values in the input data column.

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -802,7 +802,7 @@ class BinaryCifEncoders(object):
         # factor and post-FixedPoint integer chain.
         if itemConfig is not None and itemConfig.factor is not None:
             factor = itemConfig.factor
-            encoderList = [("FixedPoint", factor)] + itemConfig.integer_chain  # TODO Change "integer_chain" name
+            encoderList = [("FixedPoint", factor)] + itemConfig.integer_chain
             return self.__encodeFixedPointChainOrFallback(
                 maskedColDataList,
                 factor,

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -43,7 +43,6 @@ from mmcif.io.config import (
     FLOAT_BYTE_ARRAY_FALLBACK_CHAIN,
     MASK_ENCODING_CHAIN,
     MISSING_VALUE_TOKENS,
-    canonical_item_name,
     get_forced_type,
 )
 
@@ -134,12 +133,12 @@ class BinaryCifWriter(object):
                     cols = []
                     for ii, atName in enumerate(cObj.getAttributeList()):
                         colDataList = cObj.getColumn(ii)
-                        itemName = canonical_item_name(catName, atName)
-                        dataType = self.__getAttributeType(catName, atName, itemName, colDataList) if not self.__useStringTypes else "string"
+                        dataType = self.__getAttributeType(catName, atName, colDataList) if not self.__useStringTypes else "string"
 
-                        logger.debug("itemName %r dataType %r", itemName, dataType)
+                        logger.debug("catName %r atName %r dataType %r", catName, atName, dataType)
+                        # Pass category/item names so float columns can use coordinate-specific hints
                         colMaskDict, encodedColDataList, encodingDictL = self.__encodeColumnData(
-                            colDataList, dataType, itemName
+                            colDataList, dataType, catName, atName
                         )
                         cols.append(
                             {
@@ -163,8 +162,8 @@ class BinaryCifWriter(object):
             logger.exception("Failing with %s", str(e))
         return False
 
-    # Accept the canonical item name so encoding policy is resolved only once.
-    def __encodeColumnData(self, colDataList, dataType, itemName=""):
+    # Accept category/item names so encoder selection can use column-specific hints
+    def __encodeColumnData(self, colDataList, dataType, catName=None, atName=None):
         colMaskDict = None  # Use None when no mask and not {} - per Mol* implementation
         enc = BinaryCifEncoders(defaultStringEncoding=self.__defaultStringEncoding, storeStringsAsBytes=self.__storeStringsAsBytes, useFloat64=self.__useFloat64)
         #
@@ -192,7 +191,7 @@ class BinaryCifWriter(object):
 
         dataEncType = typeEncoderD[dataType]
         # Forward category/item names to the masked encoder
-        colDataEncoded, colDataEncodingDictL = enc.encodeWithMask(colDataList, colMaskList, dataEncType, itemName=itemName)
+        colDataEncoded, colDataEncodingDictL = enc.encodeWithMask(colDataList, colMaskList, dataEncType, catName=catName, atName=atName)
         if colMaskList:
             # Mol* indicates that masks should be encoded as if uint_8
             colMaskListTyped = TypedArray(colMaskList, "unsigned_integer_8")
@@ -216,12 +215,12 @@ class BinaryCifWriter(object):
         return strVal
 
 
-    def __getAttributeType(self, catName, atName, itemName, colDataList):
+    def __getAttributeType(self, catName, atName, colDataList):
         """Resolve a column type without changing either legacy path.
 
         Dictionary mode reproduces the original BinaryCifWriter behavior.
-        Auto-detect mode applies configured item types first, then scans the
-        values when no item policy exists.
+        Auto-detect mode applies forced types first, then scans the values, and
+        optionally uses dictionaryApi only for empty/all-sentinel columns.
         """
         if not self.__useAutoDetect:
             cifDataType = self.__dApi.getTypeCode(catName, atName)
@@ -245,7 +244,7 @@ class BinaryCifWriter(object):
                     dataType = "integer"
 
         else:
-            forcedType = get_forced_type(itemName)
+            forcedType = get_forced_type(CifName().itemName(catName, atName))
             if forcedType is not None:
                 logger.debug(
                     "Forced type override applied for %s.%s -> %s",
@@ -360,8 +359,8 @@ class BinaryCifEncoders(object):
             return colDataList.data, encodingDictL
         return colDataList, encodingDictL
 
-    # Accept a canonical item name while retaining category/item compatibility.
-    def encodeWithMask(self, colDataList, colMaskList, encodingType, catName=None, atName=None, itemName=None):
+    # Accept category/item names for float-column encoding decisions
+    def encodeWithMask(self, colDataList, colMaskList, encodingType, catName=None, atName=None):
         """Encode the data using the input mask and encoding type returning encoded data and encoding instructions.
 
         Args:
@@ -369,10 +368,10 @@ class BinaryCifEncoders(object):
             colMaskList (list): incompleteness mask for the input data column
             encodingType (string): encoding type to apply
                 (StringArrayMasked, IntArrayMasked, FloatArrayMasked)
-            catName (str, optional): category name retained for compatibility.
-            atName (str, optional): attribute name retained for compatibility.
-            itemName (str, optional): canonical item name used for configured
-                float encoding decisions.
+            catName (str, optional): category name used for float-column
+                encoding decisions. Defaults to None.
+            atName (str, optional): attribute name used for float-column
+                encoding decisions. Defaults to None.
 
         Returns:
             (list, list ): encoded data column, list of encoding instructions
@@ -383,10 +382,14 @@ class BinaryCifEncoders(object):
             encodedColDataList, encodingDictL = self.stringArrayMaskedEncoder(colDataList, colMaskList)
         elif encodingType == "IntArrayMasked":
             encodedColDataList, encodingDictL = self.intArrayMaskedEncoder(colDataList, colMaskList)
+        # Pass category/item names only to the float encoder
         elif encodingType == "FloatArrayMasked":
-            if itemName is None:
-                itemName = canonical_item_name(catName, atName)
-            encodedColDataList, encodingDictL = self.floatArrayMaskedEncoder(colDataList, colMaskList, itemName=itemName)
+            encodedColDataList, encodingDictL = self.floatArrayMaskedEncoder(
+                colDataList,
+                colMaskList,
+                catName=catName,
+                atName=atName,
+            )
         else:
             logger.info("unsupported masked encoding %r", encodingType)
         return encodedColDataList, encodingDictL
@@ -604,6 +607,16 @@ class BinaryCifEncoders(object):
         """
         return all(-2147483648 <= int(v) <= 2147483647 for v in data)
 
+    def __getItemName(self, catName, atName):
+        """Return normalized _category.attribute item name."""
+        if catName is None or atName is None:
+            return ""
+
+        if catName.startswith("_"):
+            return "%s.%s" % (catName, atName)
+        else:
+            return "_%s.%s" % (catName, atName)
+
     def __shouldUseStringFallbackForFloat(self, colDataList):
         """Return True when the column requires high-precision float fallback."""
         for val in colDataList:
@@ -774,7 +787,7 @@ class BinaryCifEncoders(object):
             logger.debug("Falling back from the fixed float chain for %s: %s", itemName, str(e))
             return self.encode(colDataList, FLOAT_BYTE_ARRAY_FALLBACK_CHAIN, "float")
 
-    def floatArrayMaskedEncoder(self, colDataList, colMaskList, catName=None, atName=None, itemName=None):
+    def floatArrayMaskedEncoder(self, colDataList, colMaskList, catName=None, atName=None):
         """Encode a float column, preserving its incompleteness mask."""
         if colMaskList:
             maskedColDataList = [0.0 if m else d for m, d in zip(colMaskList, colDataList)]
@@ -782,8 +795,7 @@ class BinaryCifEncoders(object):
             maskedColDataList = colDataList
 
         fallbackEncoderList = FLOAT_BYTE_ARRAY_FALLBACK_CHAIN
-        if itemName is None:
-            itemName = canonical_item_name(catName, atName)
+        itemName = self.__getItemName(catName, atName)
         itemConfig = BCIF_CONFIG.get_float_item_config(itemName)
 
         # Configured float items with a fixed factor use their configured

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -17,11 +17,14 @@
 #   - _FORCE_STRING_ATTRS overrides auto-detection for char-typed attributes
 #     that look numeric (e.g. _audit_conform.dict_version = "5.281").
 #
-# Float encoding updates:
-# - FixedPoint support with IntegerPacking, RunLength, and Delta chains.
-# - Column-specific chains for known high-volume float attributes.
-# - Automatic selection of the smallest general FixedPoint chain.
-# - Optional StringArray fallback for high-precision floats (disabled by default).
+#   15-Jul-2026 ym
+#   - Added FixedPoint float encoding with IntegerPacking, RunLength, and Delta
+#     chains.
+#   - Added configurable item-specific float encoding and automatic selection
+#     of the smallest general FixedPoint chain.
+#   - Moved BinaryCIF float-encoding configuration to mmcif.io.config.
+#   - Added optional StringArray fallback for high-precision floats, disabled
+#     by default.
 ##
 
 import logging
@@ -33,6 +36,7 @@ import warnings
 from mmcif.api.DataCategoryTyped import DataCategoryTyped, DataCategoryHints
 from mmcif.api.PdbxContainers import CifName
 from mmcif.io.BinaryCifReader import BinaryCifDecoders
+from mmcif.io.config import BCIF_CONFIG
 
 from mmcif.io.bcif_type_detector import classify_column
 
@@ -142,7 +146,7 @@ class BinaryCifWriter(object):
             }
             with open(filePath, "wb") as ofh:
                 msgpack.pack(data, ofh)
-            
+
             return True
         except Exception as e:
             logger.exception("Failing with %s", str(e))
@@ -176,7 +180,6 @@ class BinaryCifWriter(object):
                 else (v if isinstance(v, float) else float(v))
                 for v in colDataList
             ]
-        
 
         dataEncType = typeEncoderD[dataType]
         # Forward category/item names to the masked encoder
@@ -236,15 +239,15 @@ class BinaryCifWriter(object):
         "_struct_conn.ptnr2_auth_seq_id",
         "_struct_sheet_range.beg_auth_seq_id",
         "_struct_sheet_range.end_auth_seq_id",
-        })
-    
+    })
+
     _FORCE_FLOAT_ATTRS = frozenset({
         "_atom_site.Cartn_x",
         "_atom_site.Cartn_y",
         "_atom_site.Cartn_z",
         "_atom_site.occupancy",
         "_atom_site.B_iso_or_equiv",
- 
+
         # PDBx/mmCIF chemical component Cartesian coordinates
         "_chem_comp_atom.model_Cartn_x",
         "_chem_comp_atom.model_Cartn_y",
@@ -309,7 +312,7 @@ class BinaryCifWriter(object):
         "_flr_FPS_MPP_atom_position.ycoord",
         "_flr_FPS_MPP_atom_position.zcoord",
     })
-    
+
     def __getForcedAttributeType(self, catName, atName):
         """
         Return forced data type for known attributes.
@@ -349,7 +352,7 @@ class BinaryCifWriter(object):
                     )
             else:
                 dataType = self.__dch.getPdbxItemType(cifDataType)
-            
+
             # Mol* integer hints only apply to the dictionary-driven path.
             # In auto-detect mode, every attribute inMolStarIntHints() covers
             # is already present in _FORCE_INTEGER_ATTRS, so this is a no-op
@@ -406,140 +409,6 @@ class BinaryCifEncoders(object):
 
     """
 
-
-    # Float encoding feature switches
-    #
-    # The five individual switches below only apply when the switch is
-    # True. Disabling an individual hard-code does not force ByteArray; it sends
-    # that column through the general automatic FixedPoint chain selection.
-
-
-    # True: enable the new FixedPoint-based float encoding logic and all enabled
-    #       specialized paths below.
-    # False: bypass every float optimization below and encode all floats directly
-    #        with the original float ByteArray behavior.
-    USE_FIXED_POINT_FLOAT_ENCODING = True
-
-    # True: known coordinate columns use factor 1000 followed by
-    #       Delta -> IntegerPacking -> ByteArray.
-    # False: coordinates keep factor 1000 but use the general four-chain
-    #        comparison (Delta/RunLength variants) instead.
-    USE_COORDINATE_CHAIN = True
-
-
-    # True: the six _atom_site_anisotrop U columns use factor 10000 followed by
-    #       Delta -> IntegerPacking -> ByteArray.
-    # False: those columns skip this hard-code and use the general float path.
-    USE_ANISOTROP_U_CHAIN = True
-
-
-    # True: _ihm_sphere_obj_site.object_radius uses factor 1000 followed by
-    #       IntegerPacking -> ByteArray, without Delta or RunLength.
-    # False: object_radius skips this hard-code and uses the general float path.
-    USE_OBJECT_RADIUS_CHAIN = True
-
-
-    # True: occupancy, B_iso_or_equiv, rmsf, and starting-model B_iso_or_equiv
-    #       use an automatically detected factor followed by
-    #       RunLength -> IntegerPacking -> ByteArray.
-    # False: those four attributes skip the RunLength hint and use the general
-    #        automatic factor detection and four-chain comparison.
-    USE_RUN_LENGTH_FLOAT_HINTS = True
-
-
-    # True: when no safe FixedPoint factor is found and a column contains values
-    #       with 5 or more decimal places, encode it as StringArrayMasked.
-    # False: those high-precision fallback columns use float ByteArray instead.
-    USE_STRING_FLOAT_FALLBACK = False
-
-    COORDINATE_FIXED_POINT_FACTOR = 1000
-
-
-    ANISOTROP_U_FIXED_POINT_FACTOR = 10000
-    OBJECT_RADIUS_FIXED_POINT_FACTOR = 1000
-    MAX_FIXED_POINT_DECIMAL_PLACES = 4
-    STRING_FALLBACK_MIN_DECIMAL_PLACES = 5
-    FIXED_POINT_TOLERANCE = 1.0e-6
-
-    COORDINATE_ITEMS = frozenset({
-        # PDB / standard model coordinates
-        "_atom_site.Cartn_x",
-        "_atom_site.Cartn_y",
-        "_atom_site.Cartn_z",
-
-        # PDBx/mmCIF chemical component coordinates
-        "_chem_comp_atom.model_Cartn_x",
-        "_chem_comp_atom.model_Cartn_y",
-        "_chem_comp_atom.model_Cartn_z",
-        "_chem_comp_atom.pdbx_model_Cartn_x_ideal",
-        "_chem_comp_atom.pdbx_model_Cartn_y_ideal",
-        "_chem_comp_atom.pdbx_model_Cartn_z_ideal",
-
-        # PDBx/mmCIF phasing-site coordinates
-        "_phasing_MIR_der_site.Cartn_x",
-        "_phasing_MIR_der_site.Cartn_y",
-        "_phasing_MIR_der_site.Cartn_z",
-        "_pdbx_phasing_MAD_set_site.Cartn_x",
-        "_pdbx_phasing_MAD_set_site.Cartn_y",
-        "_pdbx_phasing_MAD_set_site.Cartn_z",
-
-        # PDBx/mmCIF solvent atom-site mapping coordinates
-        "_pdbx_solvent_atom_site_mapping.Cartn_x",
-        "_pdbx_solvent_atom_site_mapping.Cartn_y",
-        "_pdbx_solvent_atom_site_mapping.Cartn_z",
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_x",
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_y",
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_z",
-
-        # ModelCIF / CSM template coordinates
-        "_ma_template_coord.Cartn_x",
-        "_ma_template_coord.Cartn_y",
-        "_ma_template_coord.Cartn_z",
-
-        # IHM coordinates
-        "_ihm_starting_model_coord.Cartn_x",
-        "_ihm_starting_model_coord.Cartn_y",
-        "_ihm_starting_model_coord.Cartn_z",
-        "_ihm_sphere_obj_site.Cartn_x",
-        "_ihm_sphere_obj_site.Cartn_y",
-        "_ihm_sphere_obj_site.Cartn_z",
-        "_ihm_gaussian_obj_site.mean_Cartn_x",
-        "_ihm_gaussian_obj_site.mean_Cartn_y",
-        "_ihm_gaussian_obj_site.mean_Cartn_z",
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_x",
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_y",
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_z",
-        "_ihm_pseudo_site.Cartn_x",
-        "_ihm_pseudo_site.Cartn_y",
-        "_ihm_pseudo_site.Cartn_z",
-
-        # FLR / FPS coordinates
-        "_flr_FPS_mean_probe_position.mpp_xcoord",
-        "_flr_FPS_mean_probe_position.mpp_ycoord",
-        "_flr_FPS_mean_probe_position.mpp_zcoord",
-        "_flr_FPS_MPP_atom_position.xcoord",
-        "_flr_FPS_MPP_atom_position.ycoord",
-        "_flr_FPS_MPP_atom_position.zcoord",
-    })
-
-    ANISOTROP_U_ITEMS = frozenset({
-        "_atom_site_anisotrop.U[1][1]",
-        "_atom_site_anisotrop.U[1][2]",
-        "_atom_site_anisotrop.U[1][3]",
-        "_atom_site_anisotrop.U[2][2]",
-        "_atom_site_anisotrop.U[2][3]",
-        "_atom_site_anisotrop.U[3][3]",
-    })
-
-    RUN_LENGTH_FLOAT_ITEMS = frozenset({
-        "_atom_site.occupancy",
-        "_atom_site.B_iso_or_equiv",
-        "_ihm_sphere_obj_site.rmsf",
-        "_ihm_starting_model_coord.B_iso_or_equiv",
-    })
-
-    OBJECT_RADIUS_ITEM = "_ihm_sphere_obj_site.object_radius"
-
     def __init__(self, defaultStringEncoding="utf-8", storeStringsAsBytes=True, useFloat64=False):
         """Instantiate the binary CIF encoder class.
 
@@ -580,7 +449,9 @@ class BinaryCifEncoders(object):
             legacy = True
 
         encDict = None
-        # Track data type changes as chained encoders transform the array
+        # Chained encoders can change the array's data type. FixedPoint converts
+        # float values to integer_32 values, so a later ByteArray step must encode
+        # the current integer type rather than the original float input type.
         currentDataType = dataType
         for encType in encodingTypeList:
             encArg = None
@@ -613,9 +484,14 @@ class BinaryCifEncoders(object):
         """Encode the data using the input mask and encoding type returning encoded data and encoding instructions.
 
         Args:
-            colDataList (string): input data column
+            colDataList (list): input data column
             colMaskList (list): incompleteness mask for the input data column
-            encodingType (string): encoding type to apply (StringArrayMask, IntArrayMasked, FloatArrayMasked)
+            encodingType (string): encoding type to apply
+                (StringArrayMasked, IntArrayMasked, FloatArrayMasked)
+            catName (str, optional): category name used for float-column
+                encoding decisions. Defaults to None.
+            atName (str, optional): attribute name used for float-column
+                encoding decisions. Defaults to None.
 
         Returns:
             (list, list ): encoded data column, list of encoding instructions
@@ -801,6 +677,10 @@ class BinaryCifEncoders(object):
         Returns:
             TypedArray: fixed-point encoded integer list (integer_32)
             dict: binary CIF FixedPoint encoding instructions
+
+        Raises:
+            TypeError: if the input is not a float array or the scaled
+                FixedPoint values cannot be represented as signed integer_32.
         """
         if colTypedDataList.dtype and colTypedDataList.dtype not in ["float_32", "float_64"]:
             raise TypeError("Only float arrays can be encoded with FixedPoint: %s" % colTypedDataList.dtype)
@@ -842,25 +722,16 @@ class BinaryCifEncoders(object):
         """
         return all(-2147483648 <= int(v) <= 2147483647 for v in data)
 
-    # Check whether the current column is one of the known Cartesian coordinate columns
-    def __isCoordinateItem(self, catName, atName):
-        """Return True for a coordinate item that uses the factor-1000 hint."""
-        return self.__getItemName(catName, atName) in self.COORDINATE_ITEMS
-
     def __getItemName(self, catName, atName):
         """Return normalized _category.attribute item name."""
         if catName is None or atName is None:
             return ""
 
-        cat = str(catName)
+        cat = catName
         if cat.startswith("_"):
             cat = cat[1:]
 
         return "_%s.%s" % (cat, atName)
-
-    def __isAnisotropUItem(self, catName, atName):
-        """Return True for an anisotropic displacement U matrix item."""
-        return self.__getItemName(catName, atName) in self.ANISOTROP_U_ITEMS
 
     def __shouldUseStringFallbackForFloat(self, colDataList):
         """Return True when the column requires high-precision float fallback."""
@@ -879,7 +750,7 @@ class BinaryCifEncoders(object):
             else:
                 decimalPlaces = 0
 
-            if decimalPlaces >= self.STRING_FALLBACK_MIN_DECIMAL_PLACES:
+            if decimalPlaces >= BCIF_CONFIG.STRING_FALLBACK_MIN_DECIMAL_PLACES:
                 return True
 
         return False
@@ -893,12 +764,9 @@ class BinaryCifEncoders(object):
 
         return self.stringArrayMaskedEncoder(stringColDataList, colMaskList)
 
-
-    # scan the column for needed precision (fallback for -coded columns)
-    def __getFloatFixedPointFactor(self, colDataList, catName=None, atName=None):
+    # Scan the column for the precision needed by general float items.
+    def __getFloatFixedPointFactor(self, colDataList):
         """Return the smallest exact-enough FixedPoint factor for a float column."""
-        if self.__isCoordinateItem(catName, atName):
-            return self.COORDINATE_FIXED_POINT_FACTOR
 
         mantissaDigits = 0
         for val in colDataList:
@@ -908,9 +776,9 @@ class BinaryCifEncoders(object):
 
             foundDigits = None
             factor = 1
-            for digits in range(self.MAX_FIXED_POINT_DECIMAL_PLACES + 1):
+            for digits in range(BCIF_CONFIG.MAX_FIXED_POINT_DECIMAL_PLACES + 1):
                 scaledValue = factor * value
-                if abs(round(scaledValue) - scaledValue) <= self.FIXED_POINT_TOLERANCE:
+                if abs(round(scaledValue) - scaledValue) <= BCIF_CONFIG.FIXED_POINT_TOLERANCE:
                     foundDigits = digits
                     break
                 factor *= 10
@@ -932,26 +800,26 @@ class BinaryCifEncoders(object):
             [("FixedPoint", factor), "Delta", "RunLength", "IntegerPacking", "ByteArray"],
         ]
 
-        best = None
+        bestSize = None
+        bestEncodedColDataList = None
+        bestEncodingDictL = None
         for encoderList in candidateEncoderLists:
             try:
                 encodedColDataList, encodingDictL = self.encode(list(colDataList), encoderList, "float")
                 encodedData = encodedColDataList.data if isinstance(encodedColDataList, TypedArray) else encodedColDataList
                 size = len(encodedData)
 
-                if best is None or size < best[0]:
-                    best = (size, encodedColDataList, encodingDictL)
+                if bestSize is None or size < bestSize:
+                    bestSize = size
+                    bestEncodedColDataList = encodedColDataList
+                    bestEncodingDictL = encodingDictL
             except Exception as e:
                 logger.debug("Skipping float encoder chain %r: %s", encoderList, str(e))
 
-        if best is None:
+        if bestSize is None:
             return None, None
 
-        return best[1], best[2]
-
-
-
-
+        return bestEncodedColDataList, bestEncodingDictL
 
     def stringArrayMaskedEncoder(self, colDataList, colMaskList):
         """Encode the input data column (string) along with the incompleteness mask.
@@ -1018,7 +886,7 @@ class BinaryCifEncoders(object):
 
     # Encode float columns with FixedPoint chains instead of ByteArray-only when safe
     def __encodeFixedPointChainOrFallback(self, colDataList, factor, encoderList, itemName):
-        """Run one FixedPoint chain, falling back to float ByteArray when unsafe."""
+        """Run one FixedPoint chain, falling back to float ByteArray when FixedPoint is unsafe or the chain raises."""
         try:
             numericValues = [float(v) for v in colDataList]
 
@@ -1045,57 +913,80 @@ class BinaryCifEncoders(object):
             maskedColDataList = colDataList
 
         fallbackEncoderList = ["ByteArray"]
-        if not self.USE_FIXED_POINT_FLOAT_ENCODING:
-            return self.encode(maskedColDataList, fallbackEncoderList, "float")
-
         itemName = self.__getItemName(catName, atName)
+        itemConfig = BCIF_CONFIG.get_float_item_config(itemName)
 
-        # Known coordinate columns: factor 1000 + Delta.
-        if self.USE_COORDINATE_CHAIN and self.__isCoordinateItem(catName, atName):
-            factor = self.COORDINATE_FIXED_POINT_FACTOR
-            encoderList = [("FixedPoint", factor), "Delta", "IntegerPacking", "ByteArray"]
-            return self.__encodeFixedPointChainOrFallback(maskedColDataList, factor, encoderList, itemName)
+        # Forced float items with a fixed factor always use their configured
+        # factor and encoder chain.
+        if itemConfig is not None and itemConfig.factor is not None:
+            factor = itemConfig.factor
+            encoderList = BCIF_CONFIG.get_float_encoder_list(itemName)
+            return self.__encodeFixedPointChainOrFallback(
+                maskedColDataList,
+                factor,
+                encoderList,
+                itemName,
+            )
 
-        # Anisotropic U columns: factor 10000 + Delta.
-        if self.USE_ANISOTROP_U_CHAIN and self.__isAnisotropUItem(catName, atName):
-            factor = self.ANISOTROP_U_FIXED_POINT_FACTOR
-            encoderList = [("FixedPoint", factor), "Delta", "IntegerPacking", "ByteArray"]
-            return self.__encodeFixedPointChainOrFallback(maskedColDataList, factor, encoderList, itemName)
-
-        # IHM sphere radius: factor 1000 without Delta or RunLength.
-        if self.USE_OBJECT_RADIUS_CHAIN and itemName == self.OBJECT_RADIUS_ITEM:
-            factor = self.OBJECT_RADIUS_FIXED_POINT_FACTOR
-            encoderList = [("FixedPoint", factor), "IntegerPacking", "ByteArray"]
-            return self.__encodeFixedPointChainOrFallback(maskedColDataList, factor, encoderList, itemName)
-
-        # Repeated high-volume float items: automatic factor + RunLength.
-        if self.USE_RUN_LENGTH_FLOAT_HINTS and itemName in self.RUN_LENGTH_FLOAT_ITEMS:
-            factor = self.__getFloatFixedPointFactor(maskedColDataList, catName=catName, atName=atName)
+        # Selected high-volume float items may use their configured
+        # auto-detected factor and RunLength chain.
+        if (
+            itemConfig is not None
+            and itemConfig.factor is None
+            and BCIF_CONFIG.USE_RUN_LENGTH_FLOAT_HINTS
+        ):
+            factor = self.__getFloatFixedPointFactor(maskedColDataList)
             if factor is None:
-                if self.USE_STRING_FLOAT_FALLBACK and self.__shouldUseStringFallbackForFloat(maskedColDataList):
+                if (
+                    BCIF_CONFIG.USE_STRING_FLOAT_FALLBACK
+                    and self.__shouldUseStringFallbackForFloat(maskedColDataList)
+                ):
                     return self.__encodeFloatStringFallback(colDataList, colMaskList)
                 return self.encode(maskedColDataList, fallbackEncoderList, "float")
 
-            encoderList = [("FixedPoint", factor), "RunLength", "IntegerPacking", "ByteArray"]
-            return self.__encodeFixedPointChainOrFallback(maskedColDataList, factor, encoderList, itemName)
+            encoderList = [
+                ("FixedPoint", factor),
+                *itemConfig.encoderList,
+            ]
+            return self.__encodeFixedPointChainOrFallback(
+                maskedColDataList,
+                factor,
+                encoderList,
+                itemName,
+            )
 
-        # General floats: detect a factor and choose the smallest of four chains.
-        factor = self.__getFloatFixedPointFactor(maskedColDataList, catName=catName, atName=atName)
+        # General floats: auto-detect a safe FixedPoint factor.
+        factor = self.__getFloatFixedPointFactor(maskedColDataList)
         if factor is None:
-            if self.USE_STRING_FLOAT_FALLBACK and self.__shouldUseStringFallbackForFloat(maskedColDataList):
+            if (
+                BCIF_CONFIG.USE_STRING_FLOAT_FALLBACK
+                and self.__shouldUseStringFallbackForFloat(maskedColDataList)
+            ):
                 return self.__encodeFloatStringFallback(colDataList, colMaskList)
             return self.encode(maskedColDataList, fallbackEncoderList, "float")
 
-        fixedPointValues = [self.__roundLikeMolStar(float(v) * factor) for v in maskedColDataList]
-        if not self.__fitsInt32(fixedPointValues):
-            return self.encode(maskedColDataList, fallbackEncoderList, "float")
+        if BCIF_CONFIG.COMPARE_ALL_FIXED_POINT_CHAINS:
+            encodedColDataList, encodingDictL = self.__encodeBestFixedPointChain(
+                maskedColDataList,
+                factor,
+            )
+            if encodedColDataList is None:
+                return self.encode(maskedColDataList, fallbackEncoderList, "float")
+            return encodedColDataList, encodingDictL
 
-        encodedColDataList, encodingDictL = self.__encodeBestFixedPointChain(maskedColDataList, factor)
-        if encodedColDataList is None:
-            return self.encode(maskedColDataList, fallbackEncoderList, "float")
-
-        return encodedColDataList, encodingDictL
-
+        encoderList = [
+            ("FixedPoint", factor),
+            "Delta",
+            "RunLength",
+            "IntegerPacking",
+            "ByteArray",
+        ]
+        return self.__encodeFixedPointChainOrFallback(
+            maskedColDataList,
+            factor,
+            encoderList,
+            itemName,
+        )
 
     def getMask(self, colDataList):
         """Create an incompleteness mask list identifying missing/omitted values in the input data column.

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -5,6 +5,7 @@
 #  Write methods and encoders for binary CIF serialization.
 #
 #  Updates:
+#   10-Jul-2026 ha
 #   - dictionaryApi type resolution replaced with auto-detection via
 #     bcif_type_detector.classify_column().
 #   - dictionaryApi parameter is now optional (defaults to None).
@@ -105,7 +106,7 @@ class BinaryCifWriter(object):
                     # DataCategoryTyped pre-casting is only applied when a
                     # dictionaryApi is available — auto-detection works on raw
                     # string values and does not require pre-casting.
-                    if self.__applyTypes and not self.__useAutoDetect:
+                    if not self.__useAutoDetect and self.__applyTypes:
                         cObj = DataCategoryTyped(cObj, dictionaryApi=self.__dApi, copyInputData=self.__copyInputData,
                                                  ignoreCastErrors=self.__ignoreCastErrors, applyMolStarTypes=self.__applyMolStarTypes)
                     #
@@ -114,7 +115,7 @@ class BinaryCifWriter(object):
                     cols = []
                     for ii, atName in enumerate(cObj.getAttributeList()):
                         colDataList = cObj.getColumn(ii)
-                        dataType = self.__getAttributeType(cObj, atName, colDataList) if not self.__useStringTypes else "string"
+                        dataType = self.__getAttributeType(catName, atName, colDataList) if not self.__useStringTypes else "string"
 
                         logger.debug("catName %r atName %r dataType %r", catName, atName, dataType)
                         colMaskDict, encodedColDataList, encodingDictL = self.__encodeColumnData(colDataList, dataType)
@@ -167,7 +168,7 @@ class BinaryCifWriter(object):
                 else (v if isinstance(v, float) else float(v))
                 for v in colDataList
             ]
-        # dataType == "string" needs no casting — encoder handles str directly
+        
 
         dataEncType = typeEncoderD[dataType]
         colDataEncoded, colDataEncodingDictL = enc.encodeWithMask(colDataList, colMaskList, dataEncType)
@@ -197,117 +198,117 @@ class BinaryCifWriter(object):
     # These are declared as primitive type "char" in the PDBx/mmCIF dictionary.
     # Auto-detection would wrongly classify them as int or float without this
     # override (e.g. _audit_conform.dict_version = "5.281" looks like a float).
-    # Key format: "category.attribute"  (category name without leading underscore,
-    # both lowercased for case-insensitive matching).
+    # Key format: "_category.attribute"  (category name with leading underscore,
+    # case-sensitive).
     _FORCE_STRING_ATTRS = frozenset({
-        "audit_conform.dict_version",
-        "audit_conform.dict_location",
-        "audit_conform.dict_name",
-        "atom_site.group_pdb",
-        "atom_site.type_symbol",
-        "atom_site.label_atom_id",
-        "atom_site.label_comp_id",
-        "atom_site.label_asym_id",
-        "atom_site.auth_comp_id",
-        "atom_site.auth_asym_id",
-        "atom_site.auth_atom_id"
+        "_audit_conform.dict_version",
+        "_audit_conform.dict_location",
+        "_audit_conform.dict_name",
+        "_atom_site.group_PDB",
+        "_atom_site.type_symbol",
+        "_atom_site.label_atom_id",
+        "_atom_site.label_comp_id",
+        "_atom_site.label_asym_id",
+        "_atom_site.auth_comp_id",
+        "_atom_site.auth_asym_id",
+        "_atom_site.auth_atom_id"
     })
 
     _FORCE_INTEGER_ATTRS = frozenset({
-        "atom_site.id",
-        "atom_site.auth_seq_id",
-        "atom_site_anisotrop.id",
-        "pdbx_struct_mod_residue.auth_seq_id",
-        "struct_conf.beg_auth_seq_id",
-        "struct_conf.end_auth_seq_id",
-        "struct_conn.ptnr1_auth_seq_id",
-        "struct_conn.ptnr2_auth_seq_id",
-        "struct_sheet_range.beg_auth_seq_id",
-        "struct_sheet_range.end_auth_seq_id",
-        "atom_site.label_seq_id",
-        "atom_site.pdbx_pdb_model_num"
+        "_atom_site.id",
+        "_atom_site.auth_seq_id",
+        "_atom_site_anisotrop.id",
+        "_atom_site.label_seq_id",
+        "_atom_site.pdbx_PDB_model_num",
+        "_pdbx_struct_mod_residue.auth_seq_id",
+        "_struct_conf.beg_auth_seq_id",
+        "_struct_conf.end_auth_seq_id",
+        "_struct_conn.ptnr1_auth_seq_id",
+        "_struct_conn.ptnr2_auth_seq_id",
+        "_struct_sheet_range.beg_auth_seq_id",
+        "_struct_sheet_range.end_auth_seq_id",
         })
     
     _FORCE_FLOAT_ATTRS = frozenset({
-        "atom_site.cartn_x",
-        "atom_site.cartn_y",
-        "atom_site.cartn_z",
-        "atom_site.occupancy",
-        "atom_site.b_iso_or_equiv",
+        "_atom_site.Cartn_x",
+        "_atom_site.Cartn_y",
+        "_atom_site.Cartn_z",
+        "_atom_site.occupancy",
+        "_atom_site.B_iso_or_equiv",
  
         # PDBx/mmCIF chemical component Cartesian coordinates
-        "chem_comp_atom.model_cartn_x",
-        "chem_comp_atom.model_cartn_y",
-        "chem_comp_atom.model_cartn_z",
-        "chem_comp_atom.pdbx_model_cartn_x_ideal",
-        "chem_comp_atom.pdbx_model_cartn_y_ideal",
-        "chem_comp_atom.pdbx_model_cartn_z_ideal",
- 
+        "_chem_comp_atom.model_Cartn_x",
+        "_chem_comp_atom.model_Cartn_y",
+        "_chem_comp_atom.model_Cartn_z",
+        "_chem_comp_atom.pdbx_model_Cartn_x_ideal",
+        "_chem_comp_atom.pdbx_model_Cartn_y_ideal",
+        "_chem_comp_atom.pdbx_model_Cartn_z_ideal",
+
         # PDBx/mmCIF phasing-site Cartesian coordinates
-        "phasing_mir_der_site.cartn_x",
-        "phasing_mir_der_site.cartn_y",
-        "phasing_mir_der_site.cartn_z",
-        "pdbx_phasing_mad_set_site.cartn_x",
-        "pdbx_phasing_mad_set_site.cartn_y",
-        "pdbx_phasing_mad_set_site.cartn_z",
- 
+        "_phasing_MIR_der_site.Cartn_x",
+        "_phasing_MIR_der_site.Cartn_y",
+        "_phasing_MIR_der_site.Cartn_z",
+        "_pdbx_phasing_MAD_set_site.Cartn_x",
+        "_pdbx_phasing_MAD_set_site.Cartn_y",
+        "_pdbx_phasing_MAD_set_site.Cartn_z",
+
         # PDBx/mmCIF solvent atom-site mapping coordinates
-        "pdbx_solvent_atom_site_mapping.cartn_x",
-        "pdbx_solvent_atom_site_mapping.cartn_y",
-        "pdbx_solvent_atom_site_mapping.cartn_z",
-        "pdbx_solvent_atom_site_mapping.pre_cartn_x",
-        "pdbx_solvent_atom_site_mapping.pre_cartn_y",
-        "pdbx_solvent_atom_site_mapping.pre_cartn_z",
- 
+        "_pdbx_solvent_atom_site_mapping.Cartn_x",
+        "_pdbx_solvent_atom_site_mapping.Cartn_y",
+        "_pdbx_solvent_atom_site_mapping.Cartn_z",
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_x",
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_y",
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_z",
+
         # CSM / ModelCIF template Cartesian coordinates
-        "ma_template_coord.cartn_x",
-        "ma_template_coord.cartn_y",
-        "ma_template_coord.cartn_z",
- 
+        "_ma_template_coord.Cartn_x",
+        "_ma_template_coord.Cartn_y",
+        "_ma_template_coord.Cartn_z",
+
         # IHM starting-model atomic Cartesian coordinates
-        "ihm_starting_model_coord.cartn_x",
-        "ihm_starting_model_coord.cartn_y",
-        "ihm_starting_model_coord.cartn_z",
- 
+        "_ihm_starting_model_coord.Cartn_x",
+        "_ihm_starting_model_coord.Cartn_y",
+        "_ihm_starting_model_coord.Cartn_z",
+
         # IHM coarse sphere Cartesian coordinates
-        "ihm_sphere_obj_site.cartn_x",
-        "ihm_sphere_obj_site.cartn_y",
-        "ihm_sphere_obj_site.cartn_z",
- 
+        "_ihm_sphere_obj_site.Cartn_x",
+        "_ihm_sphere_obj_site.Cartn_y",
+        "_ihm_sphere_obj_site.Cartn_z",
+
         # IHM Gaussian-object mean Cartesian coordinates
-        "ihm_gaussian_obj_site.mean_cartn_x",
-        "ihm_gaussian_obj_site.mean_cartn_y",
-        "ihm_gaussian_obj_site.mean_cartn_z",
- 
+        "_ihm_gaussian_obj_site.mean_Cartn_x",
+        "_ihm_gaussian_obj_site.mean_Cartn_y",
+        "_ihm_gaussian_obj_site.mean_Cartn_z",
+
         # IHM Gaussian-ensemble mean Cartesian coordinates
-        "ihm_gaussian_obj_ensemble.mean_cartn_x",
-        "ihm_gaussian_obj_ensemble.mean_cartn_y",
-        "ihm_gaussian_obj_ensemble.mean_cartn_z",
- 
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_x",
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_y",
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_z",
+
         # IHM pseudo-site Cartesian coordinates
-        "ihm_pseudo_site.cartn_x",
-        "ihm_pseudo_site.cartn_y",
-        "ihm_pseudo_site.cartn_z",
- 
+        "_ihm_pseudo_site.Cartn_x",
+        "_ihm_pseudo_site.Cartn_y",
+        "_ihm_pseudo_site.Cartn_z",
+
         # FLR/FPS mean probe position coordinates
-        "flr_fps_mean_probe_position.mpp_xcoord",
-        "flr_fps_mean_probe_position.mpp_ycoord",
-        "flr_fps_mean_probe_position.mpp_zcoord",
- 
+        "_flr_FPS_mean_probe_position.mpp_xcoord",
+        "_flr_FPS_mean_probe_position.mpp_ycoord",
+        "_flr_FPS_mean_probe_position.mpp_zcoord",
+
         # FLR/FPS MPP atom position coordinates
-        "flr_fps_mpp_atom_position.xcoord",
-        "flr_fps_mpp_atom_position.ycoord",
-        "flr_fps_mpp_atom_position.zcoord",
+        "_flr_FPS_MPP_atom_position.xcoord",
+        "_flr_FPS_MPP_atom_position.ycoord",
+        "_flr_FPS_MPP_atom_position.zcoord",
     })
     
-    def __getForcedAttributeType(self, dObj, atName):
+    def __getForcedAttributeType(self, catName, atName):
         """
         Return forced data type for known attributes.
 
         This avoids scanning the full column with classify_column()
         when the attribute type is already known.
         """
-        atKey = "%s.%s" % (dObj.getName().lower(), atName.lower())
+        atKey = "_%s.%s" % (catName, atName)
 
         if atKey in self._FORCE_STRING_ATTRS:
             return "string"
@@ -320,7 +321,7 @@ class BinaryCifWriter(object):
 
         return None
 
-    def __getAttributeType(self, dObj, atName, colDataList):
+    def __getAttributeType(self, catName, atName, colDataList):
         """Resolve a column type without changing either legacy path.
 
         Dictionary mode reproduces the original BinaryCifWriter behavior.
@@ -328,23 +329,33 @@ class BinaryCifWriter(object):
         optionally uses dictionaryApi only for empty/all-sentinel columns.
         """
         if not self.__useAutoDetect:
-            cifDataType = self.__dApi.getTypeCode(dObj.getName(), atName)
+            cifDataType = self.__dApi.getTypeCode(catName, atName)
             if cifDataType is None:
                 dataType = "string"
                 if not self.__ignoreCastErrors:
                     logger.warning(
                         "Undefined type for category %s attribute %s - Will treat as string",
-                        dObj.getName(),
+                        catName,
                         atName,
                     )
             else:
                 dataType = self.__dch.getPdbxItemType(cifDataType)
+            
+            # Mol* integer hints only apply to the dictionary-driven path.
+            # In auto-detect mode, every attribute inMolStarIntHints() covers
+            # is already present in _FORCE_INTEGER_ATTRS, so this is a no-op
+            # there — confirmed by diffing the two sets.
+            if self.__applyTypes and self.__applyMolStarTypes:
+                nm = CifName().itemName(catName, atName)
+                if self.__dch.inMolStarIntHints(nm):
+                    dataType = "integer"
+
         else:
-            forcedType = self.__getForcedAttributeType(dObj, atName)
+            forcedType = self.__getForcedAttributeType(catName, atName)
             if forcedType is not None:
                 logger.debug(
                     "Forced type override applied for %s.%s -> %s",
-                    dObj.getName(),
+                    catName,
                     atName,
                     forcedType,
                 )
@@ -353,23 +364,6 @@ class BinaryCifWriter(object):
                 profile = classify_column(colDataList)
                 typeMap = {"int": "integer", "float": "float", "str": "string"}
                 dataType = typeMap[profile.col_type]
-
-                if profile.value_count == 0 and self.__dApi is not None:
-                    cifDataType = self.__dApi.getTypeCode(dObj.getName(), atName)
-                    if cifDataType is not None:
-                        dataType = self.__dch.getPdbxItemType(cifDataType)
-                        logger.debug(
-                            "Empty/all-sentinel column %s.%s - using dictionary type %r",
-                            dObj.getName(),
-                            atName,
-                            dataType,
-                        )
-
-        # Preserve the original Mol* hint behavior in both modes.
-        if self.__applyTypes and self.__applyMolStarTypes:
-            nm = CifName().itemName(dObj.getName(), atName)
-            if self.__dch.inMolStarIntHints(nm):
-                dataType = "integer"
 
         return dataType
 

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -1,10 +1,20 @@
 ##
-# File: BinaryCifWrite.py
+# File: BinaryCifWriter.py
 # Date: 15-May-2021  jdw
 #
 #  Write methods and encoders for binary CIF serialization.
 #
 #  Updates:
+#   - dictionaryApi type resolution replaced with auto-detection via
+#     bcif_type_detector.classify_column().
+#   - dictionaryApi parameter is now optional (defaults to None).
+#     If None, auto-detection is used for all columns.
+#     If supplied, it is used only as a fallback for all-sentinel/empty columns.
+#   - DataCategoryTyped pre-casting is skipped when dictionaryApi is None.
+#   - __encodeColumnData() casts raw string values to int/float before encoding.
+#   - __getAttributeType() uses classify_column() as primary type resolver.
+#   - _FORCE_STRING_ATTRS overrides auto-detection for char-typed attributes
+#     that look numeric (e.g. _audit_conform.dict_version = "5.281").
 #
 ##
 
@@ -17,6 +27,8 @@ from mmcif.api.DataCategoryTyped import DataCategoryTyped, DataCategoryHints
 from mmcif.api.PdbxContainers import CifName
 from mmcif.io.BinaryCifReader import BinaryCifDecoders
 
+from mmcif.io.bcif_type_detector import classify_column
+
 logger = logging.getLogger(__name__)
 
 
@@ -25,7 +37,8 @@ class BinaryCifWriter(object):
 
     def __init__(
         self,
-        dictionaryApi,
+        dictionaryApi=None,
+        useAutoDetect=True,
         storeStringsAsBytes=False,
         defaultStringEncoding="utf-8",
         applyTypes=True,
@@ -38,10 +51,18 @@ class BinaryCifWriter(object):
         """Create an instance of the binary CIF writer class.
 
         Args:
-            dictionaryApi (object): DictionaryApi object instance
+            dictionaryApi (object, optional): DictionaryApi object instance.
+                Required for dictionary-driven typing. In auto-detect mode it is
+                optional and, when supplied, is used only as a fallback for
+                empty/all-sentinel columns. Defaults to None.
+            useAutoDetect (bool, optional): Infer column types from values instead
+                of resolving every type through dictionaryApi. Defaults to False
+                to preserve the original BinaryCifWriter behavior.
             storeStringsAsBytes (bool, optional): strings are stored as lists of bytes. Defaults to False.
             defaultStringEncoding (str, optional): default encoding for string data. Defaults to "utf-8".
-            applyTypes (bool, optional): apply explicit data typing before encoding. Defaults to True.
+            applyTypes (bool, optional): apply explicit data typing before encoding.
+                Only has effect when dictionaryApi is also supplied (pre-casting
+                requires the dictionary). Defaults to True.
             useStringTypes (bool, optional): assume all types are string. Defaults to False.
             useFloat64 (bool, optional): store floats with 64 bit precision. Defaults to False.
             copyInputData (bool, optional): make a new copy input data. Defaults to False.
@@ -55,10 +76,14 @@ class BinaryCifWriter(object):
         self.__useStringTypes = useStringTypes
         self.__useFloat64 = useFloat64
         self.__dApi = dictionaryApi
+        self.__useAutoDetect = useAutoDetect
         self.__copyInputData = copyInputData
         self.__ignoreCastErrors = ignoreCastErrors
         self.__applyMolStarTypes = kwargs.get("applyMolStarTypes", True)
         self.__dch = DataCategoryHints()
+
+        if not self.__useAutoDetect and self.__dApi is None:
+            raise ValueError("dictionaryApi is required when useAutoDetect is False")
 
     def serialize(self, filePath, containerList):
         """Serialize the input container list in binary CIF and store these data in the input file path.
@@ -67,6 +92,10 @@ class BinaryCifWriter(object):
             filePath (str): output file path
             containerList (list): list of DataContainer objects
         """
+
+        dataTypeList = []
+        dataTypeList.append("New Run\n")
+
         try:
             blocks = []
             for container in containerList:
@@ -76,7 +105,10 @@ class BinaryCifWriter(object):
                 blocks.append(block)
                 for catName in container.getObjNameList():
                     cObj = container.getObj(catName)
-                    if self.__applyTypes:
+                    # DataCategoryTyped pre-casting is only applied when a
+                    # dictionaryApi is available — auto-detection works on raw
+                    # string values and does not require pre-casting.
+                    if self.__applyTypes and not self.__useAutoDetect:
                         cObj = DataCategoryTyped(cObj, dictionaryApi=self.__dApi, copyInputData=self.__copyInputData,
                                                  ignoreCastErrors=self.__ignoreCastErrors, applyMolStarTypes=self.__applyMolStarTypes)
                     #
@@ -85,7 +117,11 @@ class BinaryCifWriter(object):
                     cols = []
                     for ii, atName in enumerate(cObj.getAttributeList()):
                         colDataList = cObj.getColumn(ii)
-                        dataType = self.__getAttributeType(cObj, atName) if not self.__useStringTypes else "string"
+                        dataType = self.__getAttributeType(cObj, atName, colDataList) if not self.__useStringTypes else "string"
+
+                        fullAttrName = "_%s.%s" % (catName, atName)
+                        dataTypeList.append(fullAttrName + ": " + dataType)
+
                         logger.debug("catName %r atName %r dataType %r", catName, atName, dataType)
                         colMaskDict, encodedColDataList, encodingDictL = self.__encodeColumnData(colDataList, dataType)
                         cols.append(
@@ -104,6 +140,11 @@ class BinaryCifWriter(object):
             }
             with open(filePath, "wb") as ofh:
                 msgpack.pack(data, ofh)
+            
+            with open("dataType.txt" if self.__useAutoDetect else "dataType_dict.txt", "a") as f:
+                for item in dataTypeList:
+                    f.write(item + "\n")
+            
             return True
         except Exception as e:
             logger.exception("Failing with %s", str(e))
@@ -116,6 +157,28 @@ class BinaryCifWriter(object):
         maskEncoderList = ["RunLength", "ByteArray"]
         typeEncoderD = {"string": "StringArrayMasked", "integer": "IntArrayMasked", "float": "FloatArrayMasked"}
         colMaskList = enc.getMask(colDataList)
+
+        # When no DataCategoryTyped pre-casting was applied (dApi is None),
+        # column values arrive as raw strings. The integer and float encoders
+        # call struct.pack which requires actual int/float Python objects.
+        # Cast here using the dataType already determined by __getAttributeType.
+        # Sentinel values (".", "?", None) are left untouched so getMask()
+        # results remain valid.
+        _SENTINELS = {".", "?"}
+        if self.__useAutoDetect and dataType == "integer":
+            colDataList = [
+                v if (v is None or v in _SENTINELS)
+                else (v if isinstance(v, int) else int(v))
+                for v in colDataList
+            ]
+        elif self.__useAutoDetect and dataType == "float":
+            colDataList = [
+                v if (v is None or v in _SENTINELS)
+                else (v if isinstance(v, float) else float(v))
+                for v in colDataList
+            ]
+        # dataType == "string" needs no casting — encoder handles str directly
+
         dataEncType = typeEncoderD[dataType]
         colDataEncoded, colDataEncodingDictL = enc.encodeWithMask(colDataList, colMaskList, dataEncType)
         if colMaskList:
@@ -140,26 +203,115 @@ class BinaryCifWriter(object):
             logger.exception("Bad type for %r", strVal)
         return strVal
 
-    def __getAttributeType(self, dObj, atName):
-        """Get attribute data type (string, integer, or float) and optionality
+    # Attributes whose values look numeric but must always be encoded as strings.
+    # These are declared as primitive type "char" in the PDBx/mmCIF dictionary.
+    # Auto-detection would wrongly classify them as int or float without this
+    # override (e.g. _audit_conform.dict_version = "5.281" looks like a float).
+    # Key format: "category.attribute"  (category name without leading underscore,
+    # both lowercased for case-insensitive matching).
+    _FORCE_STRING_ATTRS = frozenset({
+        "audit_conform.dict_version",
+        "audit_conform.dict_location",
+        "audit_conform.dict_name",
+        "atom_site.group_pdb",
+        "atom_site.type_symbol",
+        "atom_site.label_atom_id",
+        "atom_site.label_comp_id",
+        "atom_site.label_asym_id",
+        "atom_site.auth_comp_id",
+        "atom_site.auth_asym_id",
+        "atom_site.auth_atom_id"
+    })
 
-        Args:
-            atName (str): attribute name
-
-        Returns:
-            (string): data type (string, integer or float)
+    _FORCE_INTEGER_ATTRS = frozenset({
+        "atom_site.id",
+        "atom_site.auth_seq_id",
+        "atom_site_anisotrop.id",
+        "pdbx_struct_mod_residue.auth_seq_id",
+        "struct_conf.beg_auth_seq_id",
+        "struct_conf.end_auth_seq_id",
+        "struct_conn.ptnr1_auth_seq_id",
+        "struct_conn.ptnr2_auth_seq_id",
+        "struct_sheet_range.beg_auth_seq_id",
+        "struct_sheet_range.end_auth_seq_id",
+        "atom_site.label_seq_id",
+        "atom_site.pdbx_pdb_model_num"
+        })
+    
+    _FORCE_FLOAT_ATTRS = frozenset({
+        "atom_site.cartn_x",
+        "atom_site.cartn_y",
+        "atom_site.cartn_z",
+        "atom_site.occupancy",
+        "atom_site.b_iso_or_equiv"
+    })
+    
+    def __getForcedAttributeType(self, dObj, atName):
         """
-        cifDataType = self.__dApi.getTypeCode(dObj.getName(), atName)
-        # cifPrimitiveType = self.__dApi.getTypePrimitive(dObj.getName(), atName)
-        if cifDataType is None:
-            dataType = "string"
-            if not self.__ignoreCastErrors:
-                logger.warning("Undefined type for category %s attribute %s - Will treat as string", dObj.getName(), atName)
-        else:
-            dataType = self.__dch.getPdbxItemType(cifDataType)
-            # dataType = "integer" if "int" in cifDataType else "float" if cifPrimitiveType == "numb" else "string"
+        Return forced data type for known attributes.
 
-        # Only if applying types, do we allow Mol* hints
+        This avoids scanning the full column with classify_column()
+        when the attribute type is already known.
+        """
+        atKey = "%s.%s" % (dObj.getName().lower(), atName.lower())
+
+        if atKey in self._FORCE_STRING_ATTRS:
+            return "string"
+
+        if atKey in self._FORCE_INTEGER_ATTRS:
+            return "integer"
+
+        if atKey in self._FORCE_FLOAT_ATTRS:
+            return "float"
+
+        return None
+
+    def __getAttributeType(self, dObj, atName, colDataList):
+        """Resolve a column type without changing either legacy path.
+
+        Dictionary mode reproduces the original BinaryCifWriter behavior.
+        Auto-detect mode applies forced types first, then scans the values, and
+        optionally uses dictionaryApi only for empty/all-sentinel columns.
+        """
+        if not self.__useAutoDetect:
+            cifDataType = self.__dApi.getTypeCode(dObj.getName(), atName)
+            if cifDataType is None:
+                dataType = "string"
+                if not self.__ignoreCastErrors:
+                    logger.warning(
+                        "Undefined type for category %s attribute %s - Will treat as string",
+                        dObj.getName(),
+                        atName,
+                    )
+            else:
+                dataType = self.__dch.getPdbxItemType(cifDataType)
+        else:
+            forcedType = self.__getForcedAttributeType(dObj, atName)
+            if forcedType is not None:
+                logger.debug(
+                    "Forced type override applied for %s.%s -> %s",
+                    dObj.getName(),
+                    atName,
+                    forcedType,
+                )
+                dataType = forcedType
+            else:
+                profile = classify_column(colDataList)
+                typeMap = {"int": "integer", "float": "float", "str": "string"}
+                dataType = typeMap[profile.col_type]
+
+                if profile.value_count == 0 and self.__dApi is not None:
+                    cifDataType = self.__dApi.getTypeCode(dObj.getName(), atName)
+                    if cifDataType is not None:
+                        dataType = self.__dch.getPdbxItemType(cifDataType)
+                        logger.debug(
+                            "Empty/all-sentinel column %s.%s - using dictionary type %r",
+                            dObj.getName(),
+                            atName,
+                            dataType,
+                        )
+
+        # Preserve the original Mol* hint behavior in both modes.
         if self.__applyTypes and self.__applyMolStarTypes:
             nm = CifName().itemName(dObj.getName(), atName)
             if self.__dch.inMolStarIntHints(nm):

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -259,7 +259,7 @@ class BinaryCifEncoders(object):
     STRING_FALLBACK_MIN_DECIMAL_PLACES = 5
     FIXED_POINT_TOLERANCE = 1.0e-6
 
-    COORDINATE_ITEMS = {
+    COORDINATE_ITEMS = frozenset({
         # PDB / standard model coordinates
         "_atom_site.Cartn_x",
         "_atom_site.Cartn_y",
@@ -318,23 +318,23 @@ class BinaryCifEncoders(object):
         "_flr_FPS_MPP_atom_position.xcoord",
         "_flr_FPS_MPP_atom_position.ycoord",
         "_flr_FPS_MPP_atom_position.zcoord",
-    }
+    })
 
-    ANISOTROP_U_ITEMS = {
+    ANISOTROP_U_ITEMS = frozenset({
         "_atom_site_anisotrop.U[1][1]",
         "_atom_site_anisotrop.U[1][2]",
         "_atom_site_anisotrop.U[1][3]",
         "_atom_site_anisotrop.U[2][2]",
         "_atom_site_anisotrop.U[2][3]",
         "_atom_site_anisotrop.U[3][3]",
-    }
+    })
 
-    RUN_LENGTH_FLOAT_ITEMS = {
+    RUN_LENGTH_FLOAT_ITEMS = frozenset({
         "_atom_site.occupancy",
         "_atom_site.B_iso_or_equiv",
         "_ihm_sphere_obj_site.rmsf",
         "_ihm_starting_model_coord.B_iso_or_equiv",
-    }
+    })
 
     OBJECT_RADIUS_ITEM = "_ihm_sphere_obj_site.object_radius"
 

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -727,11 +727,10 @@ class BinaryCifEncoders(object):
         if catName is None or atName is None:
             return ""
 
-        cat = catName
-        if cat.startswith("_"):
-            cat = cat[1:]
-
-        return "_%s.%s" % (cat, atName)
+        if catName.startswith("_"):
+            return "%s.%s" % (catName, atName)
+        else:
+            return "_%s.%s" % (catName, atName)
 
     def __shouldUseStringFallbackForFloat(self, colDataList):
         """Return True when the column requires high-precision float fallback."""
@@ -928,13 +927,8 @@ class BinaryCifEncoders(object):
                 itemName,
             )
 
-        # Selected high-volume float items may use their configured
-        # auto-detected factor and RunLength chain.
-        if (
-            itemConfig is not None
-            and itemConfig.factor is None
-            and BCIF_CONFIG.USE_RUN_LENGTH_FLOAT_HINTS
-        ):
+        # Configured auto-factor float items use their configured encoder chain.
+        if itemConfig is not None and itemConfig.factor is None:
             factor = self.__getFloatFixedPointFactor(maskedColDataList)
             if factor is None:
                 if (

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -56,8 +56,8 @@ class BinaryCifWriter(object):
                 optional and, when supplied, is used only as a fallback for
                 empty/all-sentinel columns. Defaults to None.
             useAutoDetect (bool, optional): Infer column types from values instead
-                of resolving every type through dictionaryApi. Defaults to False
-                to preserve the original BinaryCifWriter behavior.
+                of resolving every type through dictionaryApi. Defaults to True.
+                Set False to preserve the original dictionary-driven behavior.
             storeStringsAsBytes (bool, optional): strings are stored as lists of bytes. Defaults to False.
             defaultStringEncoding (str, optional): default encoding for string data. Defaults to "utf-8".
             applyTypes (bool, optional): apply explicit data typing before encoding.

--- a/mmcif/io/BinaryCifWriter.py
+++ b/mmcif/io/BinaryCifWriter.py
@@ -36,7 +36,7 @@ import warnings
 from mmcif.api.DataCategoryTyped import DataCategoryTyped, DataCategoryHints
 from mmcif.api.PdbxContainers import CifName
 from mmcif.io.BinaryCifReader import BinaryCifDecoders
-from mmcif.io.config import BCIF_CONFIG
+from mmcif.io.config import BCIF_CONFIG, canonical_item_name, get_forced_type
 
 from mmcif.io.bcif_type_detector import classify_column
 
@@ -125,11 +125,13 @@ class BinaryCifWriter(object):
                     cols = []
                     for ii, atName in enumerate(cObj.getAttributeList()):
                         colDataList = cObj.getColumn(ii)
-                        dataType = self.__getAttributeType(catName, atName, colDataList) if not self.__useStringTypes else "string"
+                        itemName = canonical_item_name(catName, atName)
+                        dataType = self.__getAttributeType(catName, atName, itemName, colDataList) if not self.__useStringTypes else "string"
 
-                        logger.debug("catName %r atName %r dataType %r", catName, atName, dataType)
-                        # Pass category/item names so float columns can use coordinate-specific hints
-                        colMaskDict, encodedColDataList, encodingDictL = self.__encodeColumnData(colDataList, dataType, catName, atName)
+                        logger.debug("itemName %r dataType %r", itemName, dataType)
+                        colMaskDict, encodedColDataList, encodingDictL = self.__encodeColumnData(
+                            colDataList, dataType, itemName
+                        )
                         cols.append(
                             {
                                 self.__toBytes("name"): self.__toBytes(atName),
@@ -152,8 +154,8 @@ class BinaryCifWriter(object):
             logger.exception("Failing with %s", str(e))
         return False
 
-    # Accept category/item names so encoder selection can use column-specific hints
-    def __encodeColumnData(self, colDataList, dataType, catName=None, atName=None):
+    # Accept the canonical item name so encoding policy is resolved only once.
+    def __encodeColumnData(self, colDataList, dataType, itemName=""):
         colMaskDict = None  # Use None when no mask and not {} - per Mol* implementation
         enc = BinaryCifEncoders(defaultStringEncoding=self.__defaultStringEncoding, storeStringsAsBytes=self.__storeStringsAsBytes, useFloat64=self.__useFloat64)
         #
@@ -183,7 +185,7 @@ class BinaryCifWriter(object):
 
         dataEncType = typeEncoderD[dataType]
         # Forward category/item names to the masked encoder
-        colDataEncoded, colDataEncodingDictL = enc.encodeWithMask(colDataList, colMaskList, dataEncType, catName=catName, atName=atName)
+        colDataEncoded, colDataEncodingDictL = enc.encodeWithMask(colDataList, colMaskList, dataEncType, itemName=itemName)
         if colMaskList:
             # Mol* indicates that masks should be encoded as if uint_8
             colMaskListTyped = TypedArray(colMaskList, "unsigned_integer_8")
@@ -206,134 +208,8 @@ class BinaryCifWriter(object):
             logger.exception("Bad type for %r", strVal)
         return strVal
 
-    # Attributes whose values look numeric but must always be encoded as strings.
-    # These are declared as primitive type "char" in the PDBx/mmCIF dictionary.
-    # Auto-detection would wrongly classify them as int or float without this
-    # override (e.g. _audit_conform.dict_version = "5.281" looks like a float).
-    # Key format: "_category.attribute"  (category name with leading underscore,
-    # case-sensitive).
-    _FORCE_STRING_ATTRS = frozenset({
-        "_audit_conform.dict_version",
-        "_audit_conform.dict_location",
-        "_audit_conform.dict_name",
-        "_atom_site.group_PDB",
-        "_atom_site.type_symbol",
-        "_atom_site.label_atom_id",
-        "_atom_site.label_comp_id",
-        "_atom_site.label_asym_id",
-        "_atom_site.auth_comp_id",
-        "_atom_site.auth_asym_id",
-        "_atom_site.auth_atom_id"
-    })
 
-    _FORCE_INTEGER_ATTRS = frozenset({
-        "_atom_site.id",
-        "_atom_site.auth_seq_id",
-        "_atom_site_anisotrop.id",
-        "_atom_site.label_seq_id",
-        "_atom_site.pdbx_PDB_model_num",
-        "_pdbx_struct_mod_residue.auth_seq_id",
-        "_struct_conf.beg_auth_seq_id",
-        "_struct_conf.end_auth_seq_id",
-        "_struct_conn.ptnr1_auth_seq_id",
-        "_struct_conn.ptnr2_auth_seq_id",
-        "_struct_sheet_range.beg_auth_seq_id",
-        "_struct_sheet_range.end_auth_seq_id",
-    })
-
-    _FORCE_FLOAT_ATTRS = frozenset({
-        "_atom_site.Cartn_x",
-        "_atom_site.Cartn_y",
-        "_atom_site.Cartn_z",
-        "_atom_site.occupancy",
-        "_atom_site.B_iso_or_equiv",
-
-        # PDBx/mmCIF chemical component Cartesian coordinates
-        "_chem_comp_atom.model_Cartn_x",
-        "_chem_comp_atom.model_Cartn_y",
-        "_chem_comp_atom.model_Cartn_z",
-        "_chem_comp_atom.pdbx_model_Cartn_x_ideal",
-        "_chem_comp_atom.pdbx_model_Cartn_y_ideal",
-        "_chem_comp_atom.pdbx_model_Cartn_z_ideal",
-
-        # PDBx/mmCIF phasing-site Cartesian coordinates
-        "_phasing_MIR_der_site.Cartn_x",
-        "_phasing_MIR_der_site.Cartn_y",
-        "_phasing_MIR_der_site.Cartn_z",
-        "_pdbx_phasing_MAD_set_site.Cartn_x",
-        "_pdbx_phasing_MAD_set_site.Cartn_y",
-        "_pdbx_phasing_MAD_set_site.Cartn_z",
-
-        # PDBx/mmCIF solvent atom-site mapping coordinates
-        "_pdbx_solvent_atom_site_mapping.Cartn_x",
-        "_pdbx_solvent_atom_site_mapping.Cartn_y",
-        "_pdbx_solvent_atom_site_mapping.Cartn_z",
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_x",
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_y",
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_z",
-
-        # CSM / ModelCIF template Cartesian coordinates
-        "_ma_template_coord.Cartn_x",
-        "_ma_template_coord.Cartn_y",
-        "_ma_template_coord.Cartn_z",
-
-        # IHM starting-model atomic Cartesian coordinates
-        "_ihm_starting_model_coord.Cartn_x",
-        "_ihm_starting_model_coord.Cartn_y",
-        "_ihm_starting_model_coord.Cartn_z",
-
-        # IHM coarse sphere Cartesian coordinates
-        "_ihm_sphere_obj_site.Cartn_x",
-        "_ihm_sphere_obj_site.Cartn_y",
-        "_ihm_sphere_obj_site.Cartn_z",
-
-        # IHM Gaussian-object mean Cartesian coordinates
-        "_ihm_gaussian_obj_site.mean_Cartn_x",
-        "_ihm_gaussian_obj_site.mean_Cartn_y",
-        "_ihm_gaussian_obj_site.mean_Cartn_z",
-
-        # IHM Gaussian-ensemble mean Cartesian coordinates
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_x",
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_y",
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_z",
-
-        # IHM pseudo-site Cartesian coordinates
-        "_ihm_pseudo_site.Cartn_x",
-        "_ihm_pseudo_site.Cartn_y",
-        "_ihm_pseudo_site.Cartn_z",
-
-        # FLR/FPS mean probe position coordinates
-        "_flr_FPS_mean_probe_position.mpp_xcoord",
-        "_flr_FPS_mean_probe_position.mpp_ycoord",
-        "_flr_FPS_mean_probe_position.mpp_zcoord",
-
-        # FLR/FPS MPP atom position coordinates
-        "_flr_FPS_MPP_atom_position.xcoord",
-        "_flr_FPS_MPP_atom_position.ycoord",
-        "_flr_FPS_MPP_atom_position.zcoord",
-    })
-
-    def __getForcedAttributeType(self, catName, atName):
-        """
-        Return forced data type for known attributes.
-
-        This avoids scanning the full column with classify_column()
-        when the attribute type is already known.
-        """
-        atKey = "_%s.%s" % (catName, atName)
-
-        if atKey in self._FORCE_STRING_ATTRS:
-            return "string"
-
-        if atKey in self._FORCE_INTEGER_ATTRS:
-            return "integer"
-
-        if atKey in self._FORCE_FLOAT_ATTRS:
-            return "float"
-
-        return None
-
-    def __getAttributeType(self, catName, atName, colDataList):
+    def __getAttributeType(self, catName, atName, itemName, colDataList):
         """Resolve a column type without changing either legacy path.
 
         Dictionary mode reproduces the original BinaryCifWriter behavior.
@@ -353,17 +229,16 @@ class BinaryCifWriter(object):
             else:
                 dataType = self.__dch.getPdbxItemType(cifDataType)
 
-            # Mol* integer hints only apply to the dictionary-driven path.
-            # In auto-detect mode, every attribute inMolStarIntHints() covers
-            # is already present in _FORCE_INTEGER_ATTRS, so this is a no-op
-            # there — confirmed by diffing the two sets.
+            # Mol* integer hints apply only to the dictionary-driven path.
+            # Auto-detect mode resolves configured integer policy before
+            # falling back to schema-less classification.
             if self.__applyTypes and self.__applyMolStarTypes:
                 nm = CifName().itemName(catName, atName)
                 if self.__dch.inMolStarIntHints(nm):
                     dataType = "integer"
 
         else:
-            forcedType = self.__getForcedAttributeType(catName, atName)
+            forcedType = get_forced_type(itemName)
             if forcedType is not None:
                 logger.debug(
                     "Forced type override applied for %s.%s -> %s",
@@ -479,8 +354,8 @@ class BinaryCifEncoders(object):
             return colDataList.data, encodingDictL
         return colDataList, encodingDictL
 
-    # Accept category/item names for float-column encoding decisions
-    def encodeWithMask(self, colDataList, colMaskList, encodingType, catName=None, atName=None):
+    # Accept a canonical item name while retaining category/item compatibility.
+    def encodeWithMask(self, colDataList, colMaskList, encodingType, catName=None, atName=None, itemName=None):
         """Encode the data using the input mask and encoding type returning encoded data and encoding instructions.
 
         Args:
@@ -488,10 +363,10 @@ class BinaryCifEncoders(object):
             colMaskList (list): incompleteness mask for the input data column
             encodingType (string): encoding type to apply
                 (StringArrayMasked, IntArrayMasked, FloatArrayMasked)
-            catName (str, optional): category name used for float-column
-                encoding decisions. Defaults to None.
-            atName (str, optional): attribute name used for float-column
-                encoding decisions. Defaults to None.
+            catName (str, optional): category name retained for compatibility.
+            atName (str, optional): attribute name retained for compatibility.
+            itemName (str, optional): canonical item name used for configured
+                float encoding decisions.
 
         Returns:
             (list, list ): encoded data column, list of encoding instructions
@@ -502,9 +377,10 @@ class BinaryCifEncoders(object):
             encodedColDataList, encodingDictL = self.stringArrayMaskedEncoder(colDataList, colMaskList)
         elif encodingType == "IntArrayMasked":
             encodedColDataList, encodingDictL = self.intArrayMaskedEncoder(colDataList, colMaskList)
-        # Pass category/item names only to the float encoder
         elif encodingType == "FloatArrayMasked":
-            encodedColDataList, encodingDictL = self.floatArrayMaskedEncoder(colDataList, colMaskList, catName=catName, atName=atName)
+            if itemName is None:
+                itemName = canonical_item_name(catName, atName)
+            encodedColDataList, encodingDictL = self.floatArrayMaskedEncoder(colDataList, colMaskList, itemName=itemName)
         else:
             logger.info("unsupported masked encoding %r", encodingType)
         return encodedColDataList, encodingDictL
@@ -722,16 +598,6 @@ class BinaryCifEncoders(object):
         """
         return all(-2147483648 <= int(v) <= 2147483647 for v in data)
 
-    def __getItemName(self, catName, atName):
-        """Return normalized _category.attribute item name."""
-        if catName is None or atName is None:
-            return ""
-
-        if catName.startswith("_"):
-            return "%s.%s" % (catName, atName)
-        else:
-            return "_%s.%s" % (catName, atName)
-
     def __shouldUseStringFallbackForFloat(self, colDataList):
         """Return True when the column requires high-precision float fallback."""
         for val in colDataList:
@@ -904,7 +770,7 @@ class BinaryCifEncoders(object):
             logger.debug("Falling back from the fixed float chain for %s: %s", itemName, str(e))
             return self.encode(colDataList, ["ByteArray"], "float")
 
-    def floatArrayMaskedEncoder(self, colDataList, colMaskList, catName=None, atName=None):
+    def floatArrayMaskedEncoder(self, colDataList, colMaskList, catName=None, atName=None, itemName=None):
         """Encode a float column, preserving its incompleteness mask."""
         if colMaskList:
             maskedColDataList = [0.0 if m else d for m, d in zip(colMaskList, colDataList)]
@@ -912,7 +778,8 @@ class BinaryCifEncoders(object):
             maskedColDataList = colDataList
 
         fallbackEncoderList = ["ByteArray"]
-        itemName = self.__getItemName(catName, atName)
+        if itemName is None:
+            itemName = canonical_item_name(catName, atName)
         itemConfig = BCIF_CONFIG.get_float_item_config(itemName)
 
         # Forced float items with a fixed factor always use their configured

--- a/mmcif/io/IoAdapterPy.py
+++ b/mmcif/io/IoAdapterPy.py
@@ -191,6 +191,7 @@ class IoAdapterPy(IoAdapterBase):
         defaultStringEncoding="utf-8",
         applyTypes=True,
         dictionaryApi=None,
+        useAutoDetect=True,
         useStringTypes=False,
         useFloat64=False,
         copyInputData=False,
@@ -214,8 +215,13 @@ class IoAdapterPy(IoAdapterBase):
             # BCIF-specific args:
             storeStringsAsBytes (bool, optional): Strings are stored as lists of bytes (for BCIF files only). Defaults to False.
             defaultStringEncoding (str, optional): Default encoding for string data (for BCIF files only). Defaults to "utf-8".
-            applyTypes (bool, optional): apply explicit data typing before encoding (for BCIF files only; requires dictionaryApi to be passed too). Defaults to True.
-            dictionaryApi (object, optional): DictionaryApi object instance (needed for BCIF files, only when applyTypes is True). Defaults to None.
+            applyTypes (bool, optional): apply explicit data typing before encoding (for BCIF files only; requires dictionaryApi to be passed too,
+                unless useAutoDetect is True). Defaults to True.
+            dictionaryApi (object, optional): DictionaryApi object instance (needed for BCIF files when useAutoDetect is False and applyTypes
+                is True). Ignored (forced to None) when useAutoDetect is True. Defaults to None.
+            useAutoDetect (bool, optional): use the automatic data-type detection system instead of the dictionaryApi-driven column typing
+                (for BCIF files only). When True (the default), dictionaryApi is ignored/forced to None and BinaryCifWriter with auto-detection is
+                used. When False, the dictionary-based BinaryCifWriter is used and dictionaryApi should be supplied. Defaults to True.
             useStringTypes (bool, optional): assume all types are string (for BCIF files only). Defaults to False.
             useFloat64 (bool, optional): store floats with 64 bit precision (for BCIF files only). Defaults to False.
             copyInputData (bool, optional): make a new copy input data (for BCIF files only). Defaults to False.
@@ -253,8 +259,12 @@ class IoAdapterPy(IoAdapterBase):
                         cnvCharRefs=self._useCharRefs,
                     )
             elif fmt == "bcif":
+                # Auto-detection path: column types are inferred directly from the data, so the
+                # dictionaryApi dependency is dropped entirely (forced to None) regardless of what
+                # was passed in.
                 bcifW = BinaryCifWriter(
-                    dictionaryApi=dictionaryApi,
+                    dictionaryApi=None if useAutoDetect else dictionaryApi,
+                    useAutoDetect=useAutoDetect,
                     storeStringsAsBytes=storeStringsAsBytes,
                     defaultStringEncoding=defaultStringEncoding,
                     applyTypes=applyTypes,

--- a/mmcif/io/bcif_type_detector.py
+++ b/mmcif/io/bcif_type_detector.py
@@ -1,0 +1,253 @@
+"""
+bcif_type_detector.py
+---------------------
+Single-pass column type detection for BinaryCIF encoding.
+
+Exports
+-------
+ColumnProfile   : dataclass holding all classification results for one column
+classify_column : scan a column list once and return a populated ColumnProfile
+
+This module has no dependency on the BinaryCIF writer, the dictionaryApi,
+or any mmcif library.  It can be imported and used independently.
+
+The three-way col_type result ("int" | "float" | "str") is a direct
+replacement for the dictionaryApi.getTypeCode() → getPdbxItemType() chain
+used in BinaryCifWrite.py.  The additional profile fields (int_width,
+max_decimals, is_sequential, has_long_runs, unique_ratio) are available
+to the writer for more precise encoding pipeline selection, but can be
+ignored if only the basic type is needed.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Module-level compiled regex — built once, shared across all calls
+# ---------------------------------------------------------------------------
+
+_INT   = re.compile(r"^-?\d+$")
+_FLOAT = re.compile(r"^-?\d+\.\d*$|^-?\d*\.\d+$")
+
+# BinaryCIF sentinel values — these represent missing/unknown data, not values
+_SENTINELS = {".", "?"}
+
+
+# ---------------------------------------------------------------------------
+# ColumnProfile dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ColumnProfile:
+    """
+    All classification results for a single column.
+
+    Fields used directly by BinaryCifWrite.py
+    ------------------------------------------
+    col_type       : "int" | "float" | "str"  — replaces dictionaryApi type lookup
+
+    Fields available for encoding optimisation
+    ------------------------------------------
+    int_width      : narrowest safe integer type ("uint8"|"int8"|"uint16"|"int16"|"int32")
+    float_prec     : float precision needed ("f32" | "f64")
+    col_min        : minimum numeric value seen (None for str columns)
+    col_max        : maximum numeric value seen (None for str columns)
+    max_decimals   : maximum decimal places seen (0 for int/str columns)
+    is_sequential  : True if integers form a consecutive 1-step sequence
+    has_long_runs  : True if any adjacent run of identical values is >= 4 long
+    unique_ratio   : len(unique values) / total non-sentinel values
+    value_count    : number of non-sentinel values
+    sentinel_count : number of sentinel ("." or "?") values
+    """
+    col_type:       str   = "str"
+    int_width:      str   = "int32"
+    float_prec:     str   = "f32"
+    col_min:        Any   = None
+    col_max:        Any   = None
+    max_decimals:   int   = 0
+    is_sequential:  bool  = False
+    has_long_runs:  bool  = False
+    unique_ratio:   float = 1.0
+    value_count:    int   = 0
+    sentinel_count: int   = 0
+
+
+# ---------------------------------------------------------------------------
+# classify_column — the single public entry point
+# ---------------------------------------------------------------------------
+
+def classify_column(values: list) -> ColumnProfile:
+    """
+    Scan a column once and return a fully populated ColumnProfile.
+
+    Design
+    ------
+    Two-phase loop:
+
+      Phase A — type probe
+        Runs until the type is conclusively decided.
+        Short-circuits (sets type_decided=True) as soon as a non-numeric value
+        is encountered, but does NOT break — the loop continues for Phase B.
+
+      Phase B — statistics
+        Always completes the full loop regardless of Phase A outcome.
+        Maintains: unique value set, adjacent run-length tracking.
+        These are needed for encoding decisions even on pure string columns.
+
+    Detection order within each value (cheapest-first):
+      isinstance check  →  char-level isdigit fast path  →  compiled regex
+
+    Parameters
+    ----------
+    values : list
+        Raw column values as returned by DataCategory.getColumn().
+        May contain strings, ints, floats, None, ".", "?".
+
+    Returns
+    -------
+    ColumnProfile
+        Fully populated.  col_type is always set to "int", "float", or "str".
+    """
+    p = ColumnProfile()
+
+    # type-probe state
+    all_int      = True
+    all_float    = True
+    type_decided = False     # flips to True once we know the column is str
+
+    # numeric accumulation
+    is_sequential = True
+    col_min       = None
+    col_max       = None
+    max_dec       = 0
+    prev          = None     # previous integer value for sequential check
+
+    # statistics (always accumulated)
+    unique        = set()
+    run_val       = None
+    run_len       = 1
+    long_run_seen = False
+    total         = 0
+    sentinels     = 0
+
+    for v in values:
+
+        # --- sentinel gate (cheapest check) ---
+        if v is None or v in _SENTINELS:
+            sentinels += 1
+            continue
+
+        total += 1
+        s = str(v).strip()
+        unique.add(s)
+
+        # --- Phase B: run-length tracking (always runs) ---
+        if s == run_val:
+            run_len += 1
+            if run_len >= 4:
+                long_run_seen = True
+        else:
+            run_val = s
+            run_len = 1
+
+        # --- Phase A: type detection (skip once type is decided) ---
+        if type_decided:
+            continue
+
+        # bool must be checked before int — bool is a subclass of int in Python
+        if isinstance(v, bool):
+            all_int = all_float = False
+            type_decided = True
+            continue
+
+        if isinstance(v, int):
+            n = v
+            all_float = False
+
+        elif isinstance(v, float):
+            all_int = False
+            dec = len(s.split(".")[1]) if "." in s else 0
+            max_dec = max(max_dec, dec)
+            col_min = v if col_min is None else min(col_min, v)
+            col_max = v if col_max is None else max(col_max, v)
+            prev = None   # floats break sequential integer assumption
+            continue
+
+        elif isinstance(v, str):
+            # char-level fast path before paying for regex
+            candidate = s[1:] if s and s[0] == "-" else s
+            if candidate.isdigit():
+                if len(candidate)>1 and candidate[0] == "0":
+                    # leading zero disqualifies integer type — treat as string
+                    all_int = all_float = False
+                    type_decided = True
+                    continue
+                #--------------------------------------
+                n = int(s)
+                all_float = False
+            elif _FLOAT.match(s):
+                all_int = False
+                f = float(s)
+                dec = len(s.split(".")[1]) if "." in s else 0
+                max_dec = max(max_dec, dec)
+                col_min = f if col_min is None else min(col_min, f)
+                col_max = f if col_max is None else max(col_max, f)
+                prev = None
+                continue
+            else:
+                # non-numeric: type decided, but loop continues for Phase B
+                all_int = all_float = False
+                type_decided = True
+                continue
+        else:
+            # unknown type — treat conservatively as string
+            all_int = all_float = False
+            type_decided = True
+            continue
+
+        # --- integer bookkeeping (reached only for confirmed int values) ---
+        col_min = n if col_min is None else min(col_min, n)
+        col_max = n if col_max is None else max(col_max, n)
+        if prev is not None and n != prev + 1:
+            is_sequential = False
+        prev = n
+
+    # ---------------------------------------------------------------------------
+    # Finalise profile
+    # ---------------------------------------------------------------------------
+
+    p.value_count    = total
+    p.sentinel_count = sentinels
+    p.col_min        = col_min
+    p.col_max        = col_max
+    p.max_decimals   = max_dec
+    p.is_sequential  = is_sequential and total > 1
+    p.has_long_runs  = long_run_seen
+    p.unique_ratio   = len(unique) / total if total else 1.0
+
+    if total == 0:
+        # Every value was a sentinel (e.g. pdbx_formal_charge all "?").
+        # No present values to type from. Default to int: cheapest encoding
+        # (IntArrayMasked fills masked with 0 → Delta+RunLength collapses),
+        # and decode is identical regardless of declared type since every
+        # value is masked.
+        p.col_type = "int"
+
+    elif all_int:
+        p.col_type = "int"
+        lo, hi = col_min, col_max
+        if   lo >= 0    and hi <= 255:   p.int_width = "uint8"
+        elif lo >= -128 and hi <= 127:   p.int_width = "int8"
+        elif lo >= 0    and hi <= 65535: p.int_width = "uint16"
+        elif lo >= -32768 and hi <= 32767: p.int_width = "int16"
+        else:                            p.int_width = "int32"
+
+    elif all_float:
+        p.col_type   = "float"
+        p.float_prec = "f32" if max_dec <= 6 else "f64"
+
+    else:
+        p.col_type = "str"
+
+    return p

--- a/mmcif/io/bcif_type_detector.py
+++ b/mmcif/io/bcif_type_detector.py
@@ -13,7 +13,7 @@ or any mmcif library.  It can be imported and used independently.
 
 The three-way col_type result ("int" | "float" | "str") is a direct
 replacement for the dictionaryApi.getTypeCode() → getPdbxItemType() chain
-used in BinaryCifWrite.py.  The additional profile fields (int_width,
+used in BinaryCifWriter.py.  The additional profile fields (int_width,
 max_decimals, is_sequential, has_long_runs, unique_ratio) are available
 to the writer for more precise encoding pipeline selection, but can be
 ignored if only the basic type is needed.
@@ -33,6 +33,11 @@ _FLOAT = re.compile(r"^-?\d+\.\d*$|^-?\d*\.\d+$")
 # BinaryCIF sentinel values — these represent missing/unknown data, not values
 _SENTINELS = {".", "?"}
 
+# If True (default), a column that would otherwise classify as "float" is forced to
+# "str" when it has fewer than _MIN_FLOAT_ROWS present (non-sentinel) values.
+FORCE_SMALL_FLOAT_AS_STRING = True
+_MIN_FLOAT_ROWS = 3
+
 
 # ---------------------------------------------------------------------------
 # ColumnProfile dataclass
@@ -43,7 +48,7 @@ class ColumnProfile:
     """
     All classification results for a single column.
 
-    Fields used directly by BinaryCifWrite.py
+    Fields used directly by BinaryCifWriter.py
     ------------------------------------------
     col_type       : "int" | "float" | "str"  — replaces dictionaryApi type lookup
 
@@ -77,20 +82,20 @@ class ColumnProfile:
 # classify_column — the single public entry point
 # ---------------------------------------------------------------------------
 
-def classify_column(values: list) -> ColumnProfile:
+def classify_column(values: list, force_small_float_as_string: bool = None) -> ColumnProfile:
     """
     Scan a column once and return a fully populated ColumnProfile.
 
     Design
     ------
-    Two-phase loop:
+    Single pass per column, two things tracked concurrently:
 
-      Phase A — type probe
+      Type Probe
         Runs until the type is conclusively decided.
         Short-circuits (sets type_decided=True) as soon as a non-numeric value
         is encountered, but does NOT break — the loop continues for Phase B.
 
-      Phase B — statistics
+      Statistics
         Always completes the full loop regardless of Phase A outcome.
         Maintains: unique value set, adjacent run-length tracking.
         These are needed for encoding decisions even on pure string columns.
@@ -103,6 +108,13 @@ def classify_column(values: list) -> ColumnProfile:
     values : list
         Raw column values as returned by DataCategory.getColumn().
         May contain strings, ints, floats, None, ".", "?".
+
+    force_small_float_as_string : bool, optional
+        Overrides the module-level FORCE_SMALL_FLOAT_AS_STRING flag for this
+        call only. If None (default), the module-level flag is used.
+        When effectively True, a column that would classify as "float" but
+        has fewer than 3 present (non-sentinel) values is forced to "str"
+        instead.
 
     Returns
     -------
@@ -142,7 +154,7 @@ def classify_column(values: list) -> ColumnProfile:
         s = str(v).strip()
         unique.add(s)
 
-        # --- Phase B: run-length tracking (always runs) ---
+        # --- run-length tracking (always runs) ---
         if s == run_val:
             run_len += 1
             if run_len >= 4:
@@ -151,11 +163,12 @@ def classify_column(values: list) -> ColumnProfile:
             run_val = s
             run_len = 1
 
-        # --- Phase A: type detection (skip once type is decided) ---
+        # --- Type Probe: type detection (skip once type is decided) ---
         if type_decided:
             continue
 
         # bool must be checked before int — bool is a subclass of int in Python
+        # Defensive check; If a CIF file contains "True" or "False" as values, treat it as string instead of bool.
         if isinstance(v, bool):
             all_int = all_float = False
             type_decided = True
@@ -196,7 +209,7 @@ def classify_column(values: list) -> ColumnProfile:
                 prev = None
                 continue
             else:
-                # non-numeric: type decided, but loop continues for Phase B
+                # non-numeric: type decided, but loop continues for Statistics
                 all_int = all_float = False
                 type_decided = True
                 continue
@@ -244,8 +257,13 @@ def classify_column(values: list) -> ColumnProfile:
         else:                            p.int_width = "int32"
 
     elif all_float:
-        p.col_type   = "float"
-        p.float_prec = "f32" if max_dec <= 6 else "f64"
+        # Assigns str data type to float columns with less than a set number of rows.
+        force_small = FORCE_SMALL_FLOAT_AS_STRING if force_small_float_as_string is None else force_small_float_as_string
+        if force_small and total < _MIN_FLOAT_ROWS:
+            p.col_type = "str"
+        else:
+            p.col_type   = "float"
+            p.float_prec = "f32" if max_dec <= 6 else "f64"
 
     else:
         p.col_type = "str"

--- a/mmcif/io/bcif_type_detector.py
+++ b/mmcif/io/bcif_type_detector.py
@@ -36,7 +36,7 @@ _SENTINELS = {".", "?"}
 # If True (default), a column that would otherwise classify as "float" is forced to
 # "str" when it has fewer than _MIN_FLOAT_ROWS present (non-sentinel) values.
 FORCE_SMALL_FLOAT_AS_STRING = True
-_MIN_FLOAT_ROWS = 3
+MIN_ROWS_TO_CLASSIFY_AS_FLOAT = 3
 
 
 # ---------------------------------------------------------------------------
@@ -259,7 +259,7 @@ def classify_column(values: list, force_small_float_as_string: bool = None) -> C
     elif all_float:
         # Assigns str data type to float columns with less than a set number of rows.
         force_small = FORCE_SMALL_FLOAT_AS_STRING if force_small_float_as_string is None else force_small_float_as_string
-        if force_small and total < _MIN_FLOAT_ROWS:
+        if force_small and total < MIN_ROWS_TO_CLASSIFY_AS_FLOAT:
             p.col_type = "str"
         else:
             p.col_type   = "float"

--- a/mmcif/io/bcif_type_detector.py
+++ b/mmcif/io/bcif_type_detector.py
@@ -8,8 +8,9 @@ Exports
 ColumnProfile   : dataclass holding all classification results for one column
 classify_column : scan a column list once and return a populated ColumnProfile
 
-This module has no dependency on the BinaryCIF writer, the dictionaryApi,
-or any mmcif library.  It can be imported and used independently.
+This module has no dependency on the BinaryCIF writer or dictionaryApi.
+It consumes immutable policy from mmcif.io.config and can otherwise be used
+independently.
 
 The three-way col_type result ("int" | "float" | "str") is a direct
 replacement for the dictionaryApi.getTypeCode() → getPdbxItemType() chain
@@ -21,6 +22,7 @@ ignored if only the basic type is needed.
 
 import re
 from dataclasses import dataclass
+from mmcif.io.config import MISSING_VALUE_TOKENS, TYPE_DETECTION_CONFIG
 from typing import Any
 
 # ---------------------------------------------------------------------------
@@ -30,13 +32,6 @@ from typing import Any
 _INT   = re.compile(r"^-?\d+$")
 _FLOAT = re.compile(r"^-?\d+\.\d*$|^-?\d*\.\d+$")
 
-# BinaryCIF sentinel values — these represent missing/unknown data, not values
-_SENTINELS = {".", "?"}
-
-# If True (default), a column that would otherwise classify as "float" is forced to
-# "str" when it has fewer than _MIN_FLOAT_ROWS present (non-sentinel) values.
-FORCE_SMALL_FLOAT_AS_STRING = True
-MIN_ROWS_TO_CLASSIFY_AS_FLOAT = 3
 
 
 # ---------------------------------------------------------------------------
@@ -82,7 +77,11 @@ class ColumnProfile:
 # classify_column — the single public entry point
 # ---------------------------------------------------------------------------
 
-def classify_column(values: list, force_small_float_as_string: bool = None) -> ColumnProfile:
+def classify_column(
+    values: list,
+    force_small_float_as_string: bool = None,
+    type_detection_config=None,
+) -> ColumnProfile:
     """
     Scan a column once and return a fully populated ColumnProfile.
 
@@ -110,17 +109,24 @@ def classify_column(values: list, force_small_float_as_string: bool = None) -> C
         May contain strings, ints, floats, None, ".", "?".
 
     force_small_float_as_string : bool, optional
-        Overrides the module-level FORCE_SMALL_FLOAT_AS_STRING flag for this
-        call only. If None (default), the module-level flag is used.
-        When effectively True, a column that would classify as "float" but
-        has fewer than 3 present (non-sentinel) values is forced to "str"
-        instead.
+        Compatibility override for the configured small-float switch.
+    type_detection_config : TypeDetectionConfig, optional
+        Immutable policy for this call. Defaults to TYPE_DETECTION_CONFIG.
+        When the effective switch is True, a column that would classify as
+        "float" but has fewer than the configured number of present
+        non-sentinel values is forced to "str".
 
     Returns
     -------
     ColumnProfile
         Fully populated.  col_type is always set to "int", "float", or "str".
     """
+    type_detection_config = type_detection_config or TYPE_DETECTION_CONFIG
+    force_small = (
+        type_detection_config.force_small_float_as_string
+        if force_small_float_as_string is None
+        else force_small_float_as_string
+    )
     p = ColumnProfile()
 
     # type-probe state
@@ -146,7 +152,7 @@ def classify_column(values: list, force_small_float_as_string: bool = None) -> C
     for v in values:
 
         # --- sentinel gate (cheapest check) ---
-        if v is None or v in _SENTINELS:
+        if v is None or v in MISSING_VALUE_TOKENS:
             sentinels += 1
             continue
 
@@ -257,9 +263,8 @@ def classify_column(values: list, force_small_float_as_string: bool = None) -> C
         else:                            p.int_width = "int32"
 
     elif all_float:
-        # Assigns str data type to float columns with less than a set number of rows.
-        force_small = FORCE_SMALL_FLOAT_AS_STRING if force_small_float_as_string is None else force_small_float_as_string
-        if force_small and total < MIN_ROWS_TO_CLASSIFY_AS_FLOAT:
+        # Apply the configurable small-float override only when enabled.
+        if force_small and total < type_detection_config.min_rows_to_classify_as_float:
             p.col_type = "str"
         else:
             p.col_type   = "float"

--- a/mmcif/io/bcif_type_detector.py
+++ b/mmcif/io/bcif_type_detector.py
@@ -14,22 +14,21 @@ independently.
 
 The three-way col_type result ("int" | "float" | "str") is a direct
 replacement for the dictionaryApi.getTypeCode() → getPdbxItemType() chain
-used in BinaryCifWriter.py.  The additional profile fields (int_width,
-max_decimals, is_sequential, has_long_runs, unique_ratio) are available
-to the writer for more precise encoding pipeline selection, but can be
-ignored if only the basic type is needed.
+used in BinaryCifWriter.py. The writer currently consumes only col_type;
+the additional profile fields are retained for callers and future encoding
+pipeline selection.
 """
 
 import re
 from dataclasses import dataclass
-from mmcif.io.config import MISSING_VALUE_TOKENS, TYPE_DETECTION_CONFIG
-from typing import Any
+from typing import Any, Optional
+
+from mmcif.io.config import MISSING_VALUE_TOKENS, TYPE_DETECTION_CONFIG, TypeDetectionConfig
 
 # ---------------------------------------------------------------------------
 # Module-level compiled regex — built once, shared across all calls
 # ---------------------------------------------------------------------------
 
-_INT   = re.compile(r"^-?\d+$")
 _FLOAT = re.compile(r"^-?\d+\.\d*$|^-?\d*\.\d+$")
 
 
@@ -79,8 +78,8 @@ class ColumnProfile:
 
 def classify_column(
     values: list,
-    force_small_float_as_string: bool = None,
-    type_detection_config=None,
+    force_small_float_as_string: Optional[bool] = None,
+    type_detection_config: Optional[TypeDetectionConfig] = None,
 ) -> ColumnProfile:
     """
     Scan a column once and return a fully populated ColumnProfile.

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -10,8 +10,7 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Optional, Tuple
 
-
-MISSING_VALUE_TOKENS = frozenset({".", "?"})
+MISSING_VALUE_TOKENS = frozenset({".", "?"})  # List of sentinels 
 
 FORCED_STRING_ITEMS = frozenset({
     "_audit_conform.dict_version",

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -83,31 +83,12 @@ TYPE_DETECTION_CONFIG = TypeDetectionConfig(
 )
 
 
-@dataclass(frozen=True, init=False)
+@dataclass(frozen=True)
 class FloatEncodingConfig:
     """FixedPoint factor and immutable post-FixedPoint integer chain."""
 
     factor: Optional[int]
     integer_chain: Tuple[str, ...]
-
-    def __init__(self, factor=1000, encoderList=None, integer_chain=None):
-        chain = integer_chain if integer_chain is not None else encoderList
-        chain = tuple(chain or ())
-        if chain and chain[0] == "FixedPoint":
-            chain = chain[1:]
-        object.__setattr__(self, "factor", factor)
-        object.__setattr__(self, "integer_chain", chain)
-
-    @property
-    def encoderList(self):
-        """Compatibility alias for the immutable post-FixedPoint chain."""
-        return self.integer_chain
-
-    def get_float_encoder_list(self):
-        """Return the full fixed-factor chain used by the current writer."""
-        if self.factor is None:
-            return None
-        return (("FixedPoint", self.factor),) + self.integer_chain
 
 
 class BinaryCifEncodingConfig:
@@ -132,102 +113,99 @@ class BinaryCifEncodingConfig:
     #        ByteArray directly without comparing alternative chains.
     COMPARE_ALL_FIXED_POINT_CHAINS = True
 
-    # Used only for items that are NOT in FORCED_FLOAT_ITEMS (general
-    # floats), or for a forced item whose factor is explicitly
-    # set to None (auto-detect), when scanning the column to find the
-    # smallest safe factor.
+    # Used for general floats and configured floats whose factor is None
+    # when scanning the column for the smallest safe factor.
     MAX_FIXED_POINT_DECIMAL_PLACES = 4
     FIXED_POINT_TOLERANCE = 1.0e-6
 
     # -----------------------------------------------------------------------
-    # Forced float data items
+    # Float item configuration
     # -----------------------------------------------------------------------
-    #
-    # Keys are full mmCIF item names, i.e. "_category.attribute".
-    # Values are FloatEncodingConfig(factor, encoderList) instances. Every item
-    # here is assumed to be a float.
+    # Keys are canonical mmCIF item names. Membership implies forced float
+    # typing. Values contain the FixedPoint factor (or None for automatic
+    # resolution) and the immutable integer chain that follows FixedPoint.
     FLOAT_ITEM_CONFIGS = MappingProxyType({
 
         # ---- Cartesian coordinates: factor 1000, FixedPoint -> Delta -> IntegerPacking -> ByteArray ----
         # PDB / standard model coordinates
-        "_atom_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_atom_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_atom_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_atom_site.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_atom_site.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
 
         # PDBx/mmCIF chemical component coordinates
-        "_chem_comp_atom.model_Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_chem_comp_atom.model_Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_chem_comp_atom.model_Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_chem_comp_atom.pdbx_model_Cartn_x_ideal": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_chem_comp_atom.pdbx_model_Cartn_y_ideal": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_chem_comp_atom.pdbx_model_Cartn_z_ideal": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_chem_comp_atom.model_Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_chem_comp_atom.model_Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_chem_comp_atom.model_Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_chem_comp_atom.pdbx_model_Cartn_x_ideal": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_chem_comp_atom.pdbx_model_Cartn_y_ideal": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_chem_comp_atom.pdbx_model_Cartn_z_ideal": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
 
         # PDBx/mmCIF phasing-site coordinates
-        "_phasing_MIR_der_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_phasing_MIR_der_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_phasing_MIR_der_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_pdbx_phasing_MAD_set_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_pdbx_phasing_MAD_set_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_pdbx_phasing_MAD_set_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_phasing_MIR_der_site.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_phasing_MIR_der_site.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_phasing_MIR_der_site.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_pdbx_phasing_MAD_set_site.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_pdbx_phasing_MAD_set_site.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_pdbx_phasing_MAD_set_site.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
 
         # PDBx/mmCIF solvent atom-site mapping coordinates
-        "_pdbx_solvent_atom_site_mapping.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_pdbx_solvent_atom_site_mapping.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_pdbx_solvent_atom_site_mapping.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_solvent_atom_site_mapping.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_pdbx_solvent_atom_site_mapping.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_pdbx_solvent_atom_site_mapping.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
 
         # ModelCIF / CSM template coordinates
-        "_ma_template_coord.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ma_template_coord.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ma_template_coord.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ma_template_coord.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ma_template_coord.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ma_template_coord.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
 
         # IHM coordinates
-        "_ihm_starting_model_coord.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_starting_model_coord.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_starting_model_coord.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_sphere_obj_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_sphere_obj_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_sphere_obj_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_gaussian_obj_site.mean_Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_gaussian_obj_site.mean_Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_gaussian_obj_site.mean_Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_pseudo_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_pseudo_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_ihm_pseudo_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_starting_model_coord.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_starting_model_coord.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_starting_model_coord.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_sphere_obj_site.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_sphere_obj_site.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_sphere_obj_site.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_gaussian_obj_site.mean_Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_gaussian_obj_site.mean_Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_gaussian_obj_site.mean_Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_pseudo_site.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_pseudo_site.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_pseudo_site.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
 
         # FLR / FPS coordinates
-        "_flr_FPS_mean_probe_position.mpp_xcoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_flr_FPS_mean_probe_position.mpp_ycoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_flr_FPS_mean_probe_position.mpp_zcoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_flr_FPS_MPP_atom_position.xcoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_flr_FPS_MPP_atom_position.ycoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_flr_FPS_MPP_atom_position.zcoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_flr_FPS_mean_probe_position.mpp_xcoord": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_flr_FPS_mean_probe_position.mpp_ycoord": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_flr_FPS_mean_probe_position.mpp_zcoord": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_flr_FPS_MPP_atom_position.xcoord": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_flr_FPS_MPP_atom_position.ycoord": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_flr_FPS_MPP_atom_position.zcoord": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
 
         # ---- Anisotropic displacement U matrix: factor 10000, FixedPoint -> Delta -> IntegerPacking -> ByteArray ----
-        "_atom_site_anisotrop.U[1][1]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_atom_site_anisotrop.U[1][2]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_atom_site_anisotrop.U[1][3]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_atom_site_anisotrop.U[2][2]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_atom_site_anisotrop.U[2][3]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
-        "_atom_site_anisotrop.U[3][3]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site_anisotrop.U[1][1]": FloatEncodingConfig(10000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_atom_site_anisotrop.U[1][2]": FloatEncodingConfig(10000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_atom_site_anisotrop.U[1][3]": FloatEncodingConfig(10000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_atom_site_anisotrop.U[2][2]": FloatEncodingConfig(10000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_atom_site_anisotrop.U[2][3]": FloatEncodingConfig(10000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_atom_site_anisotrop.U[3][3]": FloatEncodingConfig(10000, ("Delta", "IntegerPacking", "ByteArray")),
 
         # ---- IHM sphere object radius: factor 1000, no Delta/RunLength ----
-        "_ihm_sphere_obj_site.object_radius": FloatEncodingConfig(1000, ["FixedPoint", "IntegerPacking", "ByteArray"]),
+        "_ihm_sphere_obj_site.object_radius": FloatEncodingConfig(1000, ("IntegerPacking", "ByteArray")),
 
         # ---- High-volume float items: factor auto-detected from data, RunLength chain ----
         # NOTE: Setting factor=None means the caller is expected to auto-detect a safe factor from the column's data,
         #       and prepend the "FixedPoint" step to the encoder list with that factor.
-        "_atom_site.occupancy": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+        "_atom_site.occupancy": FloatEncodingConfig(None, ("RunLength", "IntegerPacking", "ByteArray")),
 
-        "_atom_site.B_iso_or_equiv": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
-        "_ihm_sphere_obj_site.rmsf": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+        "_atom_site.B_iso_or_equiv": FloatEncodingConfig(None, ("RunLength", "IntegerPacking", "ByteArray")),
+        "_ihm_sphere_obj_site.rmsf": FloatEncodingConfig(None, ("RunLength", "IntegerPacking", "ByteArray")),
 
-        "_ihm_starting_model_coord.B_iso_or_equiv": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+        "_ihm_starting_model_coord.B_iso_or_equiv": FloatEncodingConfig(None, ("RunLength", "IntegerPacking", "ByteArray")),
     })
 
     # -----------------------------------------------------------------------
@@ -245,26 +223,6 @@ class BinaryCifEncodingConfig:
             FloatEncodingConfig or None
         """
         return cls.FLOAT_ITEM_CONFIGS.get(itemName)
-
-    @classmethod
-    def get_float_encoder_list(cls, itemName):
-        """Return the resolved encoder list for itemName, if it is a forced type.
-
-        Any "FixedPoint" entry in the item's encoderList is replaced with the
-        tuple ("FixedPoint", factor), using that item's own factor.
-
-        Args:
-            itemName (str): full item name, e.g. "_atom_site.Cartn_x"
-
-        Returns:
-            list or None: the resolved encoder list, or None if itemName is
-            not in FORCED_FLOAT_ITEMS, or if it has no pre-determined
-            encoderList.
-        """
-        itemConfig = cls.get_float_item_config(itemName)
-        if itemConfig is None:
-            return None
-        return itemConfig.get_float_encoder_list()
 
 
 FLOAT_ITEM_CONFIGS = BinaryCifEncodingConfig.FLOAT_ITEM_CONFIGS

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -2,71 +2,111 @@
 # File: config.py
 # Date: 06-Jul-2026
 #
-# Configuration settings, primarily for BinaryCifWriter.py encoding behavior.
+# BinaryCIF domain policy and reusable encoding configuration.
 #
 ##
 
-_UNSET = object()
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Optional, Tuple
 
 
-def _set_float_item_names(itemConfigs):
-    """Populate each FloatEncodingConfig.name from its dictionary key."""
-    for itemName, itemConfig in itemConfigs.items():
-        itemConfig.name = itemName
-    return itemConfigs
+MISSING_VALUE_TOKENS = frozenset({".", "?"})
+
+FORCED_STRING_ITEMS = frozenset({
+    "_audit_conform.dict_version",
+    "_audit_conform.dict_location",
+    "_audit_conform.dict_name",
+    "_atom_site.group_PDB",
+    "_atom_site.type_symbol",
+    "_atom_site.label_atom_id",
+    "_atom_site.label_comp_id",
+    "_atom_site.label_asym_id",
+    "_atom_site.auth_comp_id",
+    "_atom_site.auth_asym_id",
+    "_atom_site.auth_atom_id",
+})
+
+FORCED_INTEGER_ITEMS = frozenset({
+    "_atom_site.id",
+    "_atom_site.auth_seq_id",
+    "_atom_site_anisotrop.id",
+    "_atom_site.label_seq_id",
+    "_atom_site.pdbx_PDB_model_num",
+    "_pdbx_struct_mod_residue.auth_seq_id",
+    "_struct_conf.beg_auth_seq_id",
+    "_struct_conf.end_auth_seq_id",
+    "_struct_conn.ptnr1_auth_seq_id",
+    "_struct_conn.ptnr2_auth_seq_id",
+    "_struct_sheet_range.beg_auth_seq_id",
+    "_struct_sheet_range.end_auth_seq_id",
+})
+
+SUPPORTED_ENCODERS = frozenset({"FixedPoint", "Delta", "RunLength", "IntegerPacking", "ByteArray"})
+DEFAULT_INTEGER_CHAIN = ("Delta", "RunLength", "IntegerPacking", "ByteArray")
+MASK_ENCODING_CHAIN = ("RunLength", "ByteArray")
+FLOAT_BYTE_ARRAY_FALLBACK_CHAIN = ("ByteArray",)
+DEFAULT_FIXED_POINT_INTEGER_CHAIN = ("Delta", "RunLength", "IntegerPacking", "ByteArray")
+FIXED_POINT_CANDIDATE_INTEGER_CHAINS = (
+    ("IntegerPacking", "ByteArray"),
+    ("RunLength", "IntegerPacking", "ByteArray"),
+    ("Delta", "IntegerPacking", "ByteArray"),
+    ("Delta", "RunLength", "IntegerPacking", "ByteArray"),
+)
 
 
+@dataclass(frozen=True)
+class TypeDetectionConfig:
+    """Immutable schema-less type-detection policy."""
+
+    force_small_float_as_string: bool = True
+    min_rows_to_classify_as_float: int = 3
+
+    def __post_init__(self):
+        if not isinstance(self.min_rows_to_classify_as_float, int) or isinstance(self.min_rows_to_classify_as_float, bool):
+            raise TypeError("min_rows_to_classify_as_float must be an integer")
+        if self.min_rows_to_classify_as_float < 1:
+            raise ValueError("min_rows_to_classify_as_float must be positive")
+
+
+# If True, a column that would otherwise classify as "float" is forced to
+# "str" when it has fewer than MIN_ROWS_TO_CLASSIFY_AS_FLOAT present
+# non-sentinel values.
+#
+# Keep enabled temporarily while policy is moved without changing behavior.
+FORCE_SMALL_FLOAT_AS_STRING = True
+MIN_ROWS_TO_CLASSIFY_AS_FLOAT = 3
+TYPE_DETECTION_CONFIG = TypeDetectionConfig(
+    force_small_float_as_string=FORCE_SMALL_FLOAT_AS_STRING,
+    min_rows_to_classify_as_float=MIN_ROWS_TO_CLASSIFY_AS_FLOAT,
+)
+
+
+@dataclass(frozen=True, init=False)
 class FloatEncodingConfig:
-    """Describes how a single float data item should be encoded.
+    """FixedPoint factor and immutable post-FixedPoint integer chain."""
 
-    All items tracked via FloatEncodingConfig are assumed to be floats.
+    factor: Optional[int]
+    integer_chain: Tuple[str, ...]
 
-    Attributes:
-        name (str): full item name, e.g. "_atom_site.Cartn_x"
-        factor (int or None): FixedPoint scaling factor.
-            - Not provided (default) -> 1000. (This is what _UNSET is for.)
-            - Provided as None -> no fixed factor; the caller is expected to
-              auto-detect a safe factor from the column's data (used below
-              for a handful of high-volume items that need this today).
-            - Provided as an int -> always use that fixed factor.
-        encoderList (list or None): the encoder chain for this item, e.g.
-            ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]. Include
-            the literal string "FixedPoint" wherever the FixedPoint step
-            belongs in the chain; get_float_encoder_list() will substitute in
-            the actual factor. Defaults to None (no pre-determined chain).
-    """
+    def __init__(self, factor=1000, encoderList=None, integer_chain=None):
+        chain = integer_chain if integer_chain is not None else encoderList
+        chain = tuple(chain or ())
+        if chain and chain[0] == "FixedPoint":
+            chain = chain[1:]
+        object.__setattr__(self, "factor", factor)
+        object.__setattr__(self, "integer_chain", chain)
 
-    def __init__(self, factor=_UNSET, encoderList=None, name=None):
-        self.name = name
-        self.factor = 1000 if factor is _UNSET else factor
-        self.encoderList = encoderList
+    @property
+    def encoderList(self):
+        """Compatibility alias for the immutable post-FixedPoint chain."""
+        return self.integer_chain
 
     def get_float_encoder_list(self):
-        """Return this item's encoder list, with any "FixedPoint" entry
-        replaced by the tuple ("FixedPoint", self.factor).
-
-        Returns:
-            list or None: the resolved encoder list, or None if this item
-            has no pre-determined encoderList.
-        """
-        if self.encoderList is None:
+        """Return the full fixed-factor chain used by the current writer."""
+        if self.factor is None:
             return None
-        procEncoderList = []
-        for enc in self.encoderList:
-            if enc == "FixedPoint":
-                if self.factor is None:
-                    raise ValueError(f"Forced float data item {self.name} with encoder list {self.encoderList} must have a factor defined for 'FixedPoint' encoding ({self.factor})")
-                procEncoderList.append(("FixedPoint", self.factor))
-            else:
-                procEncoderList.append(enc)
-        return procEncoderList
-
-    def __repr__(self):
-        return "FloatEncodingConfig(name=%r, factor=%r, encoderList=%r)" % (
-            self.name,
-            self.factor,
-            self.encoderList,
-        )
+        return (("FixedPoint", self.factor),) + self.integer_chain
 
 
 class BinaryCifEncodingConfig:
@@ -105,7 +145,7 @@ class BinaryCifEncodingConfig:
     # Keys are full mmCIF item names, i.e. "_category.attribute".
     # Values are FloatEncodingConfig(factor, encoderList) instances. Every item
     # here is assumed to be a float.
-    FORCED_FLOAT_ITEMS = _set_float_item_names({
+    FLOAT_ITEM_CONFIGS = MappingProxyType({
 
         # ---- Cartesian coordinates: factor 1000, FixedPoint -> Delta -> IntegerPacking -> ByteArray ----
         # PDB / standard model coordinates
@@ -182,8 +222,10 @@ class BinaryCifEncodingConfig:
         # NOTE: Setting factor=None means the caller is expected to auto-detect a safe factor from the column's data,
         #       and prepend the "FixedPoint" step to the encoder list with that factor.
         "_atom_site.occupancy": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+
         "_atom_site.B_iso_or_equiv": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
         "_ihm_sphere_obj_site.rmsf": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+
         "_ihm_starting_model_coord.B_iso_or_equiv": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
     })
 
@@ -201,7 +243,7 @@ class BinaryCifEncodingConfig:
         Returns:
             FloatEncodingConfig or None
         """
-        return cls.FORCED_FLOAT_ITEMS.get(itemName)
+        return cls.FLOAT_ITEM_CONFIGS.get(itemName)
 
     @classmethod
     def get_float_encoder_list(cls, itemName):
@@ -224,4 +266,66 @@ class BinaryCifEncodingConfig:
         return itemConfig.get_float_encoder_list()
 
 
+FLOAT_ITEM_CONFIGS = BinaryCifEncodingConfig.FLOAT_ITEM_CONFIGS
+
+
+def canonical_item_name(category_name, attribute_name):
+    """Return the canonical, case-sensitive _category.attribute name."""
+    if category_name is None or attribute_name is None:
+        return ""
+    if category_name.startswith("_"):
+        return "%s.%s" % (category_name, attribute_name)
+    return "_%s.%s" % (category_name, attribute_name)
+
+
+def get_forced_type(item_name):
+    """Return a configured writer type for a canonical item name, if any."""
+    if item_name in FORCED_STRING_ITEMS:
+        return "string"
+    if item_name in FORCED_INTEGER_ITEMS:
+        return "integer"
+    if item_name in FLOAT_ITEM_CONFIGS:
+        return "float"
+    return None
+
+
+def validate_binary_cif_config():
+    """Raise ValueError for contradictory or unsupported BinaryCIF policy."""
+    errors = []
+    if FORCED_STRING_ITEMS & FORCED_INTEGER_ITEMS:
+        errors.append("items cannot be both forced string and forced integer")
+    if FORCED_STRING_ITEMS & set(FLOAT_ITEM_CONFIGS):
+        errors.append("forced string items cannot have float configurations")
+    if FORCED_INTEGER_ITEMS & set(FLOAT_ITEM_CONFIGS):
+        errors.append("forced integer items cannot have float configurations")
+
+    reusable_chains = FIXED_POINT_CANDIDATE_INTEGER_CHAINS + (
+        DEFAULT_FIXED_POINT_INTEGER_CHAIN,
+        DEFAULT_INTEGER_CHAIN,
+        FLOAT_BYTE_ARRAY_FALLBACK_CHAIN,
+        MASK_ENCODING_CHAIN,
+    )
+    for chain in reusable_chains:
+        unsupported = set(chain) - SUPPORTED_ENCODERS
+        if unsupported:
+            errors.append("unsupported encoders: %s" % sorted(unsupported))
+
+    for item_name, item_config in FLOAT_ITEM_CONFIGS.items():
+        if item_config.factor is not None and (
+            not isinstance(item_config.factor, int)
+            or isinstance(item_config.factor, bool)
+            or item_config.factor <= 0
+        ):
+            errors.append("%s has an invalid FixedPoint factor" % item_name)
+        unsupported = set(item_config.integer_chain) - SUPPORTED_ENCODERS
+        if unsupported:
+            errors.append("%s has unsupported encoders: %s" % (item_name, sorted(unsupported)))
+
+    if errors:
+        raise ValueError("; ".join(errors))
+    return True
+
+
 BCIF_CONFIG = BinaryCifEncodingConfig()
+
+validate_binary_cif_config()

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -214,7 +214,7 @@ class BinaryCifEncodingConfig:
 
     @classmethod
     def get_float_item_config(cls, itemName):
-        """Return the FloatEncodingConfig for itemName, or None if it isn't a forced type.
+        """Return the FloatEncodingConfig for itemName, or None if it is not configured.
 
         Args:
             itemName (str): full item name, e.g. "_atom_site.Cartn_x"

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -8,7 +8,7 @@
 
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 
 MISSING_VALUE_TOKENS = frozenset({".", "?"})  # List of sentinels
@@ -43,16 +43,16 @@ FORCED_INTEGER_ITEMS = frozenset({
 })
 
 SUPPORTED_ENCODERS = frozenset({"FixedPoint", "Delta", "RunLength", "IntegerPacking", "ByteArray"})
-DEFAULT_INTEGER_CHAIN = ("Delta", "RunLength", "IntegerPacking", "ByteArray")
-MASK_ENCODING_CHAIN = ("RunLength", "ByteArray")
-FLOAT_BYTE_ARRAY_FALLBACK_CHAIN = ("ByteArray",)
-DEFAULT_FIXED_POINT_INTEGER_CHAIN = ("Delta", "RunLength", "IntegerPacking", "ByteArray")
-FIXED_POINT_CANDIDATE_INTEGER_CHAINS = (
-    ("IntegerPacking", "ByteArray"),
-    ("RunLength", "IntegerPacking", "ByteArray"),
-    ("Delta", "IntegerPacking", "ByteArray"),
-    ("Delta", "RunLength", "IntegerPacking", "ByteArray"),
-)
+DEFAULT_INTEGER_CHAIN = ["Delta", "RunLength", "IntegerPacking", "ByteArray"]
+MASK_ENCODING_CHAIN = ["RunLength", "ByteArray"]
+FLOAT_BYTE_ARRAY_FALLBACK_CHAIN = ["ByteArray"]
+DEFAULT_FIXED_POINT_INTEGER_CHAIN = ["Delta", "RunLength", "IntegerPacking", "ByteArray"]
+FIXED_POINT_CANDIDATE_INTEGER_CHAINS = [
+    ["IntegerPacking", "ByteArray"],
+    ["RunLength", "IntegerPacking", "ByteArray"],
+    ["Delta", "IntegerPacking", "ByteArray"],
+    ["Delta", "RunLength", "IntegerPacking", "ByteArray"],
+]
 
 
 @dataclass(frozen=True)
@@ -85,10 +85,21 @@ TYPE_DETECTION_CONFIG = TypeDetectionConfig(
 
 @dataclass(frozen=True)
 class FloatEncodingConfig:
-    """FixedPoint factor and immutable post-FixedPoint integer chain."""
+    """FixedPoint factor and immutable post-FixedPoint integer chain.
+
+    Attributes:
+        factor (int or None): FixedPoint scaling factor.
+            - Provided as None -> no fixed factor; the caller is expected to
+              auto-detect a safe factor from the column's data (used below
+              for a handful of high-volume items that need this).
+            - Provided as an int -> always use that fixed factor.
+        integer_chain (list or None): the integer encoder chain for this item,
+            following FixedPoint conversion, e.g. ["Delta", "IntegerPacking", "ByteArray"].
+            Note that ("FixedPoint", factor) is preprended by BinaryCifWriter.
+    """
 
     factor: Optional[int]
-    integer_chain: Tuple[str, ...]
+    integer_chain: List[str, ...]
 
 
 class BinaryCifEncodingConfig:
@@ -132,82 +143,84 @@ class BinaryCifEncodingConfig:
 
         # ---- Cartesian coordinates: factor 1000, FixedPoint -> Delta -> IntegerPacking -> ByteArray ----
         # PDB / standard model coordinates
-        "_atom_site.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_atom_site.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_atom_site.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_atom_site.Cartn_x": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site.Cartn_y": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site.Cartn_z": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
 
         # PDBx/mmCIF chemical component coordinates
-        "_chem_comp_atom.model_Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_chem_comp_atom.model_Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_chem_comp_atom.model_Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_chem_comp_atom.pdbx_model_Cartn_x_ideal": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_chem_comp_atom.pdbx_model_Cartn_y_ideal": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_chem_comp_atom.pdbx_model_Cartn_z_ideal": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_chem_comp_atom.model_Cartn_x": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_chem_comp_atom.model_Cartn_y": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_chem_comp_atom.model_Cartn_z": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_chem_comp_atom.pdbx_model_Cartn_x_ideal": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_chem_comp_atom.pdbx_model_Cartn_y_ideal": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_chem_comp_atom.pdbx_model_Cartn_z_ideal": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
 
         # PDBx/mmCIF phasing-site coordinates
-        "_phasing_MIR_der_site.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_phasing_MIR_der_site.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_phasing_MIR_der_site.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_pdbx_phasing_MAD_set_site.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_pdbx_phasing_MAD_set_site.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_pdbx_phasing_MAD_set_site.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_phasing_MIR_der_site.Cartn_x": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_phasing_MIR_der_site.Cartn_y": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_phasing_MIR_der_site.Cartn_z": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_phasing_MAD_set_site.Cartn_x": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_phasing_MAD_set_site.Cartn_y": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_phasing_MAD_set_site.Cartn_z": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
 
         # PDBx/mmCIF solvent atom-site mapping coordinates
-        "_pdbx_solvent_atom_site_mapping.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_pdbx_solvent_atom_site_mapping.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_pdbx_solvent_atom_site_mapping.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_pdbx_solvent_atom_site_mapping.pre_Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_pdbx_solvent_atom_site_mapping.Cartn_x": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_solvent_atom_site_mapping.Cartn_y": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_solvent_atom_site_mapping.Cartn_z": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_x": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_y": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_z": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
 
         # ModelCIF / CSM template coordinates
-        "_ma_template_coord.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_ma_template_coord.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_ma_template_coord.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ma_template_coord.Cartn_x": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_ma_template_coord.Cartn_y": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_ma_template_coord.Cartn_z": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
 
         # IHM coordinates
-        "_ihm_starting_model_coord.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_ihm_starting_model_coord.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_ihm_starting_model_coord.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_ihm_sphere_obj_site.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_ihm_sphere_obj_site.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_ihm_sphere_obj_site.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_ihm_gaussian_obj_site.mean_Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_ihm_gaussian_obj_site.mean_Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_ihm_gaussian_obj_site.mean_Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_ihm_gaussian_obj_ensemble.mean_Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_ihm_pseudo_site.Cartn_x": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_ihm_pseudo_site.Cartn_y": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_ihm_pseudo_site.Cartn_z": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_ihm_starting_model_coord.Cartn_x": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_starting_model_coord.Cartn_y": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_starting_model_coord.Cartn_z": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_sphere_obj_site.Cartn_x": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_sphere_obj_site.Cartn_y": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_sphere_obj_site.Cartn_z": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_gaussian_obj_site.mean_Cartn_x": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_gaussian_obj_site.mean_Cartn_y": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_gaussian_obj_site.mean_Cartn_z": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_x": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_y": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_z": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_pseudo_site.Cartn_x": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_pseudo_site.Cartn_y": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_pseudo_site.Cartn_z": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
 
         # FLR / FPS coordinates
-        "_flr_FPS_mean_probe_position.mpp_xcoord": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_flr_FPS_mean_probe_position.mpp_ycoord": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_flr_FPS_mean_probe_position.mpp_zcoord": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_flr_FPS_MPP_atom_position.xcoord": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_flr_FPS_MPP_atom_position.ycoord": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_flr_FPS_MPP_atom_position.zcoord": FloatEncodingConfig(1000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_flr_FPS_mean_probe_position.mpp_xcoord": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_flr_FPS_mean_probe_position.mpp_ycoord": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_flr_FPS_mean_probe_position.mpp_zcoord": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_flr_FPS_MPP_atom_position.xcoord": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_flr_FPS_MPP_atom_position.ycoord": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_flr_FPS_MPP_atom_position.zcoord": FloatEncodingConfig(1000, ["Delta", "IntegerPacking", "ByteArray"]),
 
         # ---- Anisotropic displacement U matrix: factor 10000, FixedPoint -> Delta -> IntegerPacking -> ByteArray ----
-        "_atom_site_anisotrop.U[1][1]": FloatEncodingConfig(10000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_atom_site_anisotrop.U[1][2]": FloatEncodingConfig(10000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_atom_site_anisotrop.U[1][3]": FloatEncodingConfig(10000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_atom_site_anisotrop.U[2][2]": FloatEncodingConfig(10000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_atom_site_anisotrop.U[2][3]": FloatEncodingConfig(10000, ("Delta", "IntegerPacking", "ByteArray")),
-        "_atom_site_anisotrop.U[3][3]": FloatEncodingConfig(10000, ("Delta", "IntegerPacking", "ByteArray")),
+        "_atom_site_anisotrop.U[1][1]": FloatEncodingConfig(10000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site_anisotrop.U[1][2]": FloatEncodingConfig(10000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site_anisotrop.U[1][3]": FloatEncodingConfig(10000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site_anisotrop.U[2][2]": FloatEncodingConfig(10000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site_anisotrop.U[2][3]": FloatEncodingConfig(10000, ["Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site_anisotrop.U[3][3]": FloatEncodingConfig(10000, ["Delta", "IntegerPacking", "ByteArray"]),
 
         # ---- IHM sphere object radius: factor 1000, no Delta/RunLength ----
-        "_ihm_sphere_obj_site.object_radius": FloatEncodingConfig(1000, ("IntegerPacking", "ByteArray")),
+        "_ihm_sphere_obj_site.object_radius": FloatEncodingConfig(1000, ["IntegerPacking", "ByteArray"]),
 
         # ---- High-volume float items: factor auto-detected from data, RunLength chain ----
-        "_atom_site.occupancy": FloatEncodingConfig(None, ("RunLength", "IntegerPacking", "ByteArray")),
+        # NOTE: Setting factor=None means the caller is expected to auto-detect a safe factor from the column's data,
+        #       and prepend the "FixedPoint" step to the encoder list with that factor.
+        "_atom_site.occupancy": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
 
-        "_atom_site.B_iso_or_equiv": FloatEncodingConfig(None, ("RunLength", "IntegerPacking", "ByteArray")),
-        "_ihm_sphere_obj_site.rmsf": FloatEncodingConfig(None, ("RunLength", "IntegerPacking", "ByteArray")),
+        "_atom_site.B_iso_or_equiv": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+        "_ihm_sphere_obj_site.rmsf": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
 
-        "_ihm_starting_model_coord.B_iso_or_equiv": FloatEncodingConfig(None, ("RunLength", "IntegerPacking", "ByteArray")),
+        "_ihm_starting_model_coord.B_iso_or_equiv": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
     })
 
     # -----------------------------------------------------------------------
@@ -251,12 +264,12 @@ def validate_binary_cif_config():
     if FORCED_INTEGER_ITEMS & set(FORCED_FLOAT_ITEMS):
         errors.append("forced integer items cannot have float configurations")
 
-    reusable_chains = FIXED_POINT_CANDIDATE_INTEGER_CHAINS + (
+    reusable_chains = FIXED_POINT_CANDIDATE_INTEGER_CHAINS + [
         DEFAULT_FIXED_POINT_INTEGER_CHAIN,
         DEFAULT_INTEGER_CHAIN,
         FLOAT_BYTE_ARRAY_FALLBACK_CHAIN,
         MASK_ENCODING_CHAIN,
-    )
+    ]
     for chain in reusable_chains:
         unsupported = set(chain) - SUPPORTED_ENCODERS
         if unsupported:

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -59,7 +59,7 @@ FIXED_POINT_CANDIDATE_INTEGER_CHAINS = (
 class TypeDetectionConfig:
     """Immutable schema-less type-detection policy."""
 
-    force_small_float_as_string: bool = True
+    force_small_float_as_string: bool = False
     min_rows_to_classify_as_float: int = 3
 
     def __post_init__(self):
@@ -73,8 +73,9 @@ class TypeDetectionConfig:
 # "str" when it has fewer than MIN_ROWS_TO_CLASSIFY_AS_FLOAT present
 # non-sentinel values.
 #
-# Keep enabled temporarily while policy is moved without changing behavior.
-FORCE_SMALL_FLOAT_AS_STRING = True
+# Keep disabled by default. Enabling this may increase BCIF file size by
+# up to 7%.
+FORCE_SMALL_FLOAT_AS_STRING = False
 MIN_ROWS_TO_CLASSIFY_AS_FLOAT = 3
 TYPE_DETECTION_CONFIG = TypeDetectionConfig(
     force_small_float_as_string=FORCE_SMALL_FLOAT_AS_STRING,

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -8,7 +8,7 @@
 
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Optional, Tuple, List
+from typing import Optional, List
 
 
 MISSING_VALUE_TOKENS = frozenset({".", "?"})  # List of sentinels

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -2,7 +2,7 @@
 # File: config.py
 # Date: 06-Jul-2026
 #
-# BinaryCIF domain policy and reusable encoding configuration.
+# Configuration settings, primarily for BinaryCifWriter.py encoding behavior.
 #
 ##
 
@@ -10,7 +10,8 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Optional, Tuple
 
-MISSING_VALUE_TOKENS = frozenset({".", "?"})  # List of sentinels 
+
+MISSING_VALUE_TOKENS = frozenset({".", "?"})  # List of sentinels
 
 FORCED_STRING_ITEMS = frozenset({
     "_audit_conform.dict_version",
@@ -227,15 +228,6 @@ class BinaryCifEncodingConfig:
 
 
 FORCED_FLOAT_ITEMS = BinaryCifEncodingConfig.FLOAT_ITEM_CONFIGS
-
-
-def canonical_item_name(category_name, attribute_name):
-    """Return the canonical, case-sensitive _category.attribute name."""
-    if category_name is None or attribute_name is None:
-        return ""
-    if category_name.startswith("_"):
-        return "%s.%s" % (category_name, attribute_name)
-    return "_%s.%s" % (category_name, attribute_name)
 
 
 def get_forced_type(item_name):

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -99,7 +99,7 @@ class FloatEncodingConfig:
     """
 
     factor: Optional[int]
-    integer_chain: List[str, ...]
+    integer_chain: List[str]
 
 
 class BinaryCifEncodingConfig:

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -225,7 +225,7 @@ class BinaryCifEncodingConfig:
         return cls.FLOAT_ITEM_CONFIGS.get(itemName)
 
 
-FLOAT_ITEM_CONFIGS = BinaryCifEncodingConfig.FLOAT_ITEM_CONFIGS
+FORCED_FLOAT_ITEMS = BinaryCifEncodingConfig.FLOAT_ITEM_CONFIGS
 
 
 def canonical_item_name(category_name, attribute_name):
@@ -243,7 +243,7 @@ def get_forced_type(item_name):
         return "string"
     if item_name in FORCED_INTEGER_ITEMS:
         return "integer"
-    if item_name in FLOAT_ITEM_CONFIGS:
+    if item_name in FORCED_FLOAT_ITEMS:
         return "float"
     return None
 
@@ -253,9 +253,9 @@ def validate_binary_cif_config():
     errors = []
     if FORCED_STRING_ITEMS & FORCED_INTEGER_ITEMS:
         errors.append("items cannot be both forced string and forced integer")
-    if FORCED_STRING_ITEMS & set(FLOAT_ITEM_CONFIGS):
+    if FORCED_STRING_ITEMS & set(FORCED_FLOAT_ITEMS):
         errors.append("forced string items cannot have float configurations")
-    if FORCED_INTEGER_ITEMS & set(FLOAT_ITEM_CONFIGS):
+    if FORCED_INTEGER_ITEMS & set(FORCED_FLOAT_ITEMS):
         errors.append("forced integer items cannot have float configurations")
 
     reusable_chains = FIXED_POINT_CANDIDATE_INTEGER_CHAINS + (
@@ -269,7 +269,7 @@ def validate_binary_cif_config():
         if unsupported:
             errors.append("unsupported encoders: %s" % sorted(unsupported))
 
-    for item_name, item_config in FLOAT_ITEM_CONFIGS.items():
+    for item_name, item_config in FORCED_FLOAT_ITEMS.items():
         if item_config.factor is not None and (
             not isinstance(item_config.factor, int)
             or isinstance(item_config.factor, bool)

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -76,12 +76,6 @@ class BinaryCifEncodingConfig:
     # Global float-encoding switches
     # -----------------------------------------------------------------------
 
-    # True:  use the configured RunLength encoding chains for selected
-    #        high-volume float items.
-    # False: treat those items as general floats and use automatic factor
-    #        detection and general FixedPoint chain selection.
-    USE_RUN_LENGTH_FLOAT_HINTS = True
-
     # True:  when no safe FixedPoint factor is found (general/undetected
     #        items only) and a column contains values with 5 or more decimal
     #        places, encode it as StringArrayMasked.

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -122,8 +122,12 @@ class BinaryCifEncodingConfig:
     # Float item configuration
     # -----------------------------------------------------------------------
     # Keys are canonical mmCIF item names. Membership implies forced float
-    # typing. Values contain the FixedPoint factor (or None for automatic
-    # resolution) and the immutable integer chain that follows FixedPoint.
+    # typing. Each configuration contains a FixedPoint factor and the immutable
+    # integer encoding chain applied after FixedPoint.
+    #
+    # BinaryCifWriter always prepends ("FixedPoint", factor) to the configured
+    # integer chain. If factor is an integer, that value is used. If factor=None,
+    # the writer first detects a safe factor from the column data.
     FLOAT_ITEM_CONFIGS = MappingProxyType({
 
         # ---- Cartesian coordinates: factor 1000, FixedPoint -> Delta -> IntegerPacking -> ByteArray ----
@@ -198,8 +202,6 @@ class BinaryCifEncodingConfig:
         "_ihm_sphere_obj_site.object_radius": FloatEncodingConfig(1000, ("IntegerPacking", "ByteArray")),
 
         # ---- High-volume float items: factor auto-detected from data, RunLength chain ----
-        # NOTE: Setting factor=None means the caller is expected to auto-detect a safe factor from the column's data,
-        #       and prepend the "FixedPoint" step to the encoder list with that factor.
         "_atom_site.occupancy": FloatEncodingConfig(None, ("RunLength", "IntegerPacking", "ByteArray")),
 
         "_atom_site.B_iso_or_equiv": FloatEncodingConfig(None, ("RunLength", "IntegerPacking", "ByteArray")),

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -179,6 +179,8 @@ class BinaryCifEncodingConfig:
         "_ihm_sphere_obj_site.object_radius": FloatEncodingConfig(1000, ["FixedPoint", "IntegerPacking", "ByteArray"]),
 
         # ---- High-volume float items: factor auto-detected from data, RunLength chain ----
+        # NOTE: Setting factor=None means the caller is expected to auto-detect a safe factor from the column's data,
+        #       and prepend the "FixedPoint" step to the encoder list with that factor.
         "_atom_site.occupancy": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
         "_atom_site.B_iso_or_equiv": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
         "_ihm_sphere_obj_site.rmsf": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),

--- a/mmcif/io/config.py
+++ b/mmcif/io/config.py
@@ -1,0 +1,231 @@
+##
+# File: config.py
+# Date: 06-Jul-2026
+#
+# Configuration settings, primarily for BinaryCifWriter.py encoding behavior.
+#
+##
+
+_UNSET = object()
+
+
+def _set_float_item_names(itemConfigs):
+    """Populate each FloatEncodingConfig.name from its dictionary key."""
+    for itemName, itemConfig in itemConfigs.items():
+        itemConfig.name = itemName
+    return itemConfigs
+
+
+class FloatEncodingConfig:
+    """Describes how a single float data item should be encoded.
+
+    All items tracked via FloatEncodingConfig are assumed to be floats.
+
+    Attributes:
+        name (str): full item name, e.g. "_atom_site.Cartn_x"
+        factor (int or None): FixedPoint scaling factor.
+            - Not provided (default) -> 1000. (This is what _UNSET is for.)
+            - Provided as None -> no fixed factor; the caller is expected to
+              auto-detect a safe factor from the column's data (used below
+              for a handful of high-volume items that need this today).
+            - Provided as an int -> always use that fixed factor.
+        encoderList (list or None): the encoder chain for this item, e.g.
+            ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]. Include
+            the literal string "FixedPoint" wherever the FixedPoint step
+            belongs in the chain; get_float_encoder_list() will substitute in
+            the actual factor. Defaults to None (no pre-determined chain).
+    """
+
+    def __init__(self, factor=_UNSET, encoderList=None, name=None):
+        self.name = name
+        self.factor = 1000 if factor is _UNSET else factor
+        self.encoderList = encoderList
+
+    def get_float_encoder_list(self):
+        """Return this item's encoder list, with any "FixedPoint" entry
+        replaced by the tuple ("FixedPoint", self.factor).
+
+        Returns:
+            list or None: the resolved encoder list, or None if this item
+            has no pre-determined encoderList.
+        """
+        if self.encoderList is None:
+            return None
+        procEncoderList = []
+        for enc in self.encoderList:
+            if enc == "FixedPoint":
+                if self.factor is None:
+                    raise ValueError(f"Forced float data item {self.name} with encoder list {self.encoderList} must have a factor defined for 'FixedPoint' encoding ({self.factor})")
+                procEncoderList.append(("FixedPoint", self.factor))
+            else:
+                procEncoderList.append(enc)
+        return procEncoderList
+
+    def __repr__(self):
+        return "FloatEncodingConfig(name=%r, factor=%r, encoderList=%r)" % (
+            self.name,
+            self.factor,
+            self.encoderList,
+        )
+
+
+class BinaryCifEncodingConfig:
+    """Container for all BinaryCifWriter float-encoding configuration."""
+
+    # -----------------------------------------------------------------------
+    # Global float-encoding switches
+    # -----------------------------------------------------------------------
+
+    # True:  use the configured RunLength encoding chains for selected
+    #        high-volume float items.
+    # False: treat those items as general floats and use automatic factor
+    #        detection and general FixedPoint chain selection.
+    USE_RUN_LENGTH_FLOAT_HINTS = True
+
+    # True:  when no safe FixedPoint factor is found (general/undetected
+    #        items only) and a column contains values with 5 or more decimal
+    #        places, encode it as StringArrayMasked.
+    # False: those high-precision fallback columns use float ByteArray
+    #        instead.
+    # NOTE: If set to True, the 'testSerialize' test will need to be updated.
+    USE_STRING_FLOAT_FALLBACK = False
+    STRING_FALLBACK_MIN_DECIMAL_PLACES = 5
+
+    # True:  for general float items with a safe FixedPoint factor, compare all
+    #        four supported integer encoding chains and use the smallest output.
+    # False: use FixedPoint -> Delta -> RunLength -> IntegerPacking ->
+    #        ByteArray directly without comparing alternative chains.
+    COMPARE_ALL_FIXED_POINT_CHAINS = True
+
+    # Used only for items that are NOT in FORCED_FLOAT_ITEMS (general
+    # floats), or for a forced item whose factor is explicitly
+    # set to None (auto-detect), when scanning the column to find the
+    # smallest safe factor.
+    MAX_FIXED_POINT_DECIMAL_PLACES = 4
+    FIXED_POINT_TOLERANCE = 1.0e-6
+
+    # -----------------------------------------------------------------------
+    # Forced float data items
+    # -----------------------------------------------------------------------
+    #
+    # Keys are full mmCIF item names, i.e. "_category.attribute".
+    # Values are FloatEncodingConfig(factor, encoderList) instances. Every item
+    # here is assumed to be a float.
+    FORCED_FLOAT_ITEMS = _set_float_item_names({
+
+        # ---- Cartesian coordinates: factor 1000, FixedPoint -> Delta -> IntegerPacking -> ByteArray ----
+        # PDB / standard model coordinates
+        "_atom_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+
+        # PDBx/mmCIF chemical component coordinates
+        "_chem_comp_atom.model_Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_chem_comp_atom.model_Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_chem_comp_atom.model_Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_chem_comp_atom.pdbx_model_Cartn_x_ideal": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_chem_comp_atom.pdbx_model_Cartn_y_ideal": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_chem_comp_atom.pdbx_model_Cartn_z_ideal": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+
+        # PDBx/mmCIF phasing-site coordinates
+        "_phasing_MIR_der_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_phasing_MIR_der_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_phasing_MIR_der_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_phasing_MAD_set_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_phasing_MAD_set_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_phasing_MAD_set_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+
+        # PDBx/mmCIF solvent atom-site mapping coordinates
+        "_pdbx_solvent_atom_site_mapping.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_solvent_atom_site_mapping.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_solvent_atom_site_mapping.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_pdbx_solvent_atom_site_mapping.pre_Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+
+        # ModelCIF / CSM template coordinates
+        "_ma_template_coord.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ma_template_coord.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ma_template_coord.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+
+        # IHM coordinates
+        "_ihm_starting_model_coord.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_starting_model_coord.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_starting_model_coord.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_sphere_obj_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_sphere_obj_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_sphere_obj_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_gaussian_obj_site.mean_Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_gaussian_obj_site.mean_Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_gaussian_obj_site.mean_Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_gaussian_obj_ensemble.mean_Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_pseudo_site.Cartn_x": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_pseudo_site.Cartn_y": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_ihm_pseudo_site.Cartn_z": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+
+        # FLR / FPS coordinates
+        "_flr_FPS_mean_probe_position.mpp_xcoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_flr_FPS_mean_probe_position.mpp_ycoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_flr_FPS_mean_probe_position.mpp_zcoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_flr_FPS_MPP_atom_position.xcoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_flr_FPS_MPP_atom_position.ycoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_flr_FPS_MPP_atom_position.zcoord": FloatEncodingConfig(1000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+
+        # ---- Anisotropic displacement U matrix: factor 10000, FixedPoint -> Delta -> IntegerPacking -> ByteArray ----
+        "_atom_site_anisotrop.U[1][1]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site_anisotrop.U[1][2]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site_anisotrop.U[1][3]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site_anisotrop.U[2][2]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site_anisotrop.U[2][3]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+        "_atom_site_anisotrop.U[3][3]": FloatEncodingConfig(10000, ["FixedPoint", "Delta", "IntegerPacking", "ByteArray"]),
+
+        # ---- IHM sphere object radius: factor 1000, no Delta/RunLength ----
+        "_ihm_sphere_obj_site.object_radius": FloatEncodingConfig(1000, ["FixedPoint", "IntegerPacking", "ByteArray"]),
+
+        # ---- High-volume float items: factor auto-detected from data, RunLength chain ----
+        "_atom_site.occupancy": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+        "_atom_site.B_iso_or_equiv": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+        "_ihm_sphere_obj_site.rmsf": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+        "_ihm_starting_model_coord.B_iso_or_equiv": FloatEncodingConfig(None, ["RunLength", "IntegerPacking", "ByteArray"]),
+    })
+
+    # -----------------------------------------------------------------------
+    # Accessors
+    # -----------------------------------------------------------------------
+
+    @classmethod
+    def get_float_item_config(cls, itemName):
+        """Return the FloatEncodingConfig for itemName, or None if it isn't a forced type.
+
+        Args:
+            itemName (str): full item name, e.g. "_atom_site.Cartn_x"
+
+        Returns:
+            FloatEncodingConfig or None
+        """
+        return cls.FORCED_FLOAT_ITEMS.get(itemName)
+
+    @classmethod
+    def get_float_encoder_list(cls, itemName):
+        """Return the resolved encoder list for itemName, if it is a forced type.
+
+        Any "FixedPoint" entry in the item's encoderList is replaced with the
+        tuple ("FixedPoint", factor), using that item's own factor.
+
+        Args:
+            itemName (str): full item name, e.g. "_atom_site.Cartn_x"
+
+        Returns:
+            list or None: the resolved encoder list, or None if itemName is
+            not in FORCED_FLOAT_ITEMS, or if it has no pre-determined
+            encoderList.
+        """
+        itemConfig = cls.get_float_item_config(itemName)
+        if itemConfig is None:
+            return None
+        return itemConfig.get_float_encoder_list()
+
+
+BCIF_CONFIG = BinaryCifEncodingConfig()

--- a/mmcif/tests/testBcifTypeDetector.py
+++ b/mmcif/tests/testBcifTypeDetector.py
@@ -1,0 +1,83 @@
+##
+# File: testBcifTypeDetector.py
+#
+# Characterization tests for schema-less BinaryCIF column classification.
+##
+
+import unittest
+
+from mmcif.io.bcif_type_detector import classify_column
+from mmcif.io.config import TypeDetectionConfig
+
+
+class BcifTypeDetectorTests(unittest.TestCase):
+    def assertColumnType(self, expected, values, config=None):
+        profile = classify_column(values, type_detection_config=config)
+        self.assertEqual(profile.col_type, expected)
+
+    def testNumericAndStringCharacterization(self):
+        cases = [
+            ("int", ["1", "2", "3"]),
+            ("int", [1, 2, 3]),
+            ("float", ["1.25", "2.50", "3.75"]),
+            ("float", [1.25, 2.5, 3.75]),
+            ("int", ["-3", "-2", "-1"]),
+            ("float", ["-3.5", "-2.5", "-1.5"]),
+            ("str", ["0004"]),
+            ("str", ["1e-3", "2e-3", "3e-3"]),
+            ("str", [True, False]),
+            ("int", [".", "?", None]),
+            ("int", [".", "1", "?", "2"]),
+            ("float", [".", "1.5", "?", "2.5", "3.5"]),
+            ("str", [".", "alpha", "?", "beta"]),
+            ("str", ["1", "2.5", "3"]),
+            ("int", []),
+            ("int", [" 1 ", " 2 ", " 3 "]),
+            ("float", [" 1.5 ", " 2.5 ", " 3.5 "]),
+        ]
+        for expected, values in cases:
+            with self.subTest(values=values):
+                self.assertColumnType(expected, values)
+
+    def testSmallFloatOverrideDisabled(self):
+        config = TypeDetectionConfig(
+            force_small_float_as_string=False,
+            min_rows_to_classify_as_float=3,
+        )
+        for values in (["1.5"], ["1.5", "2.5"], ["1.5", "2.5", "3.5"]):
+            with self.subTest(values=values):
+                self.assertColumnType("float", values, config)
+
+    def testSmallFloatOverrideEnabled(self):
+        config = TypeDetectionConfig(
+            force_small_float_as_string=True,
+            min_rows_to_classify_as_float=3,
+        )
+        self.assertColumnType("str", ["1.5"], config)
+        self.assertColumnType("str", ["1.5", "2.5"], config)
+        self.assertColumnType("float", ["1.5", "2.5", "3.5"], config)
+
+    def testSentinelsDoNotCountTowardSmallFloatThreshold(self):
+        config = TypeDetectionConfig(
+            force_small_float_as_string=True,
+            min_rows_to_classify_as_float=3,
+        )
+        self.assertColumnType("str", [".", "1.5", "?", "2.5", None], config)
+        self.assertColumnType("float", [".", "1.5", "?", "2.5", "3.5"], config)
+
+    def testConfiguredThresholdOnlyAffectsEnabledOverride(self):
+        enabled = TypeDetectionConfig(
+            force_small_float_as_string=True,
+            min_rows_to_classify_as_float=2,
+        )
+        disabled = TypeDetectionConfig(
+            force_small_float_as_string=False,
+            min_rows_to_classify_as_float=99,
+        )
+        self.assertColumnType("str", ["1.5"], enabled)
+        self.assertColumnType("float", ["1.5", "2.5"], enabled)
+        self.assertColumnType("float", ["1.5"], disabled)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mmcif/tests/testBinaryCifConfig.py
+++ b/mmcif/tests/testBinaryCifConfig.py
@@ -1,0 +1,81 @@
+##
+# File: testBinaryCifConfig.py
+#
+# Invariants for centralized BinaryCIF policy and reusable encoding chains.
+##
+
+import unittest
+
+from mmcif.io.config import (
+    DEFAULT_FIXED_POINT_INTEGER_CHAIN,
+    DEFAULT_INTEGER_CHAIN,
+    FIXED_POINT_CANDIDATE_INTEGER_CHAINS,
+    FLOAT_BYTE_ARRAY_FALLBACK_CHAIN,
+    FLOAT_ITEM_CONFIGS,
+    FORCED_INTEGER_ITEMS,
+    FORCED_STRING_ITEMS,
+    MASK_ENCODING_CHAIN,
+    MISSING_VALUE_TOKENS,
+    SUPPORTED_ENCODERS,
+    TYPE_DETECTION_CONFIG,
+    canonical_item_name,
+    get_forced_type,
+    validate_binary_cif_config,
+)
+
+
+class BinaryCifConfigTests(unittest.TestCase):
+    def testItemPoliciesDoNotConflict(self):
+        self.assertFalse(FORCED_STRING_ITEMS & FORCED_INTEGER_ITEMS)
+        self.assertFalse(FORCED_STRING_ITEMS & set(FLOAT_ITEM_CONFIGS))
+        self.assertFalse(FORCED_INTEGER_ITEMS & set(FLOAT_ITEM_CONFIGS))
+
+    def testEveryFloatConfigForcesFloatType(self):
+        for item_name in FLOAT_ITEM_CONFIGS:
+            with self.subTest(item_name=item_name):
+                self.assertEqual(get_forced_type(item_name), "float")
+
+    def testEncoderNamesAndFactorsAreValid(self):
+        chains = list(FIXED_POINT_CANDIDATE_INTEGER_CHAINS) + [
+            DEFAULT_FIXED_POINT_INTEGER_CHAIN,
+            DEFAULT_INTEGER_CHAIN,
+            FLOAT_BYTE_ARRAY_FALLBACK_CHAIN,
+            MASK_ENCODING_CHAIN,
+        ]
+        for chain in chains:
+            self.assertIsInstance(chain, tuple)
+            self.assertTrue(set(chain) <= SUPPORTED_ENCODERS)
+
+        for item_name, item_config in FLOAT_ITEM_CONFIGS.items():
+            with self.subTest(item_name=item_name):
+                self.assertIsInstance(item_config.integer_chain, tuple)
+                self.assertTrue(set(item_config.integer_chain) <= SUPPORTED_ENCODERS)
+                if item_config.factor is not None:
+                    self.assertIsInstance(item_config.factor, int)
+                    self.assertGreater(item_config.factor, 0)
+
+    def testReusableConfigurationIsImmutable(self):
+        self.assertIsInstance(MISSING_VALUE_TOKENS, frozenset)
+        self.assertIsInstance(FORCED_STRING_ITEMS, frozenset)
+        self.assertIsInstance(FORCED_INTEGER_ITEMS, frozenset)
+        self.assertIsInstance(FIXED_POINT_CANDIDATE_INTEGER_CHAINS, tuple)
+        with self.assertRaises(TypeError):
+            FLOAT_ITEM_CONFIGS["_test.value"] = object()
+
+    def testCanonicalItemNamesAndForcedLookup(self):
+        self.assertEqual(canonical_item_name("atom_site", "Cartn_x"), "_atom_site.Cartn_x")
+        self.assertEqual(canonical_item_name("_atom_site", "Cartn_x"), "_atom_site.Cartn_x")
+        self.assertEqual(get_forced_type("_audit_conform.dict_version"), "string")
+        self.assertEqual(get_forced_type("_atom_site.id"), "integer")
+        self.assertIsNone(get_forced_type("_task1_test.unconfigured"))
+
+    def testDefaultTypeDetectionPolicy(self):
+        self.assertFalse(TYPE_DETECTION_CONFIG.force_small_float_as_string)
+        self.assertEqual(TYPE_DETECTION_CONFIG.min_rows_to_classify_as_float, 3)
+
+    def testValidationHelperAcceptsDefaultConfiguration(self):
+        self.assertTrue(validate_binary_cif_config())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mmcif/tests/testBinaryCifConfig.py
+++ b/mmcif/tests/testBinaryCifConfig.py
@@ -18,7 +18,6 @@ from mmcif.io.config import (
     MISSING_VALUE_TOKENS,
     SUPPORTED_ENCODERS,
     TYPE_DETECTION_CONFIG,
-    canonical_item_name,
     get_forced_type,
     validate_binary_cif_config,
 )
@@ -62,9 +61,7 @@ class BinaryCifConfigTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             FORCED_FLOAT_ITEMS["_test.value"] = object()
 
-    def testCanonicalItemNamesAndForcedLookup(self):
-        self.assertEqual(canonical_item_name("atom_site", "Cartn_x"), "_atom_site.Cartn_x")
-        self.assertEqual(canonical_item_name("_atom_site", "Cartn_x"), "_atom_site.Cartn_x")
+    def testForcedTypeLookup(self):
         self.assertEqual(get_forced_type("_audit_conform.dict_version"), "string")
         self.assertEqual(get_forced_type("_atom_site.id"), "integer")
         self.assertIsNone(get_forced_type("_task1_test.unconfigured"))

--- a/mmcif/tests/testBinaryCifConfig.py
+++ b/mmcif/tests/testBinaryCifConfig.py
@@ -42,12 +42,12 @@ class BinaryCifConfigTests(unittest.TestCase):
             MASK_ENCODING_CHAIN,
         ]
         for chain in chains:
-            self.assertIsInstance(chain, tuple)
+            self.assertIsInstance(chain, list)
             self.assertTrue(set(chain) <= SUPPORTED_ENCODERS)
 
         for item_name, item_config in FORCED_FLOAT_ITEMS.items():
             with self.subTest(item_name=item_name):
-                self.assertIsInstance(item_config.integer_chain, tuple)
+                self.assertIsInstance(item_config.integer_chain, list)
                 self.assertTrue(set(item_config.integer_chain) <= SUPPORTED_ENCODERS)
                 if item_config.factor is not None:
                     self.assertIsInstance(item_config.factor, int)

--- a/mmcif/tests/testBinaryCifConfig.py
+++ b/mmcif/tests/testBinaryCifConfig.py
@@ -11,7 +11,7 @@ from mmcif.io.config import (
     DEFAULT_INTEGER_CHAIN,
     FIXED_POINT_CANDIDATE_INTEGER_CHAINS,
     FLOAT_BYTE_ARRAY_FALLBACK_CHAIN,
-    FLOAT_ITEM_CONFIGS,
+    FORCED_FLOAT_ITEMS,
     FORCED_INTEGER_ITEMS,
     FORCED_STRING_ITEMS,
     MASK_ENCODING_CHAIN,
@@ -27,11 +27,11 @@ from mmcif.io.config import (
 class BinaryCifConfigTests(unittest.TestCase):
     def testItemPoliciesDoNotConflict(self):
         self.assertFalse(FORCED_STRING_ITEMS & FORCED_INTEGER_ITEMS)
-        self.assertFalse(FORCED_STRING_ITEMS & set(FLOAT_ITEM_CONFIGS))
-        self.assertFalse(FORCED_INTEGER_ITEMS & set(FLOAT_ITEM_CONFIGS))
+        self.assertFalse(FORCED_STRING_ITEMS & set(FORCED_FLOAT_ITEMS))
+        self.assertFalse(FORCED_INTEGER_ITEMS & set(FORCED_FLOAT_ITEMS))
 
     def testEveryFloatConfigForcesFloatType(self):
-        for item_name in FLOAT_ITEM_CONFIGS:
+        for item_name in FORCED_FLOAT_ITEMS:
             with self.subTest(item_name=item_name):
                 self.assertEqual(get_forced_type(item_name), "float")
 
@@ -46,7 +46,7 @@ class BinaryCifConfigTests(unittest.TestCase):
             self.assertIsInstance(chain, tuple)
             self.assertTrue(set(chain) <= SUPPORTED_ENCODERS)
 
-        for item_name, item_config in FLOAT_ITEM_CONFIGS.items():
+        for item_name, item_config in FORCED_FLOAT_ITEMS.items():
             with self.subTest(item_name=item_name):
                 self.assertIsInstance(item_config.integer_chain, tuple)
                 self.assertTrue(set(item_config.integer_chain) <= SUPPORTED_ENCODERS)
@@ -60,7 +60,7 @@ class BinaryCifConfigTests(unittest.TestCase):
         self.assertIsInstance(FORCED_INTEGER_ITEMS, frozenset)
         self.assertIsInstance(FIXED_POINT_CANDIDATE_INTEGER_CHAINS, tuple)
         with self.assertRaises(TypeError):
-            FLOAT_ITEM_CONFIGS["_test.value"] = object()
+            FORCED_FLOAT_ITEMS["_test.value"] = object()
 
     def testCanonicalItemNamesAndForcedLookup(self):
         self.assertEqual(canonical_item_name("atom_site", "Cartn_x"), "_atom_site.Cartn_x")

--- a/mmcif/tests/testBinaryCifConfig.py
+++ b/mmcif/tests/testBinaryCifConfig.py
@@ -57,7 +57,7 @@ class BinaryCifConfigTests(unittest.TestCase):
         self.assertIsInstance(MISSING_VALUE_TOKENS, frozenset)
         self.assertIsInstance(FORCED_STRING_ITEMS, frozenset)
         self.assertIsInstance(FORCED_INTEGER_ITEMS, frozenset)
-        self.assertIsInstance(FIXED_POINT_CANDIDATE_INTEGER_CHAINS, tuple)
+        self.assertIsInstance(FIXED_POINT_CANDIDATE_INTEGER_CHAINS, list)
         with self.assertRaises(TypeError):
             FORCED_FLOAT_ITEMS["_test.value"] = object()
 

--- a/mmcif/tests/testBinaryCifWriter.py
+++ b/mmcif/tests/testBinaryCifWriter.py
@@ -80,11 +80,16 @@ class BinaryCifWriterTests(unittest.TestCase):
         # 8CCS caused failure to decode
         self.__testCifList = ["1BNA", "1A2C", "1ACJ", "1J59", "1D3I",
                               "1ONX", "1PGA", "4CXL", "5ZMZ", "200L",
-                              "4HHB", "7NO1", "1OCD", "8CCS"]
+                              "4HHB", #"7NO1", "1OCD", "8CCS"
+                              ]
         self.__testBcifOutput = os.path.join(self.__pathOutputDir, "1bna-generated.bcif")
         self.__testBcifTranslated = os.path.join(self.__pathOutputDir, "1bna-generated-translated.bcif")
         self.__testBcifTypeOutput = os.path.join(self.__pathOutputDir, "type-generated.bcif")
-
+        #
+        # Auto-detect (dictionary-free) outputs - kept distinct from the dictionary-driven
+        # outputs above so the two tests never clobber each other's files.
+        self.__testBcifAutoOutput = os.path.join(self.__pathOutputDir, "1bna-autoDetect-generated.bcif")
+        self.__testBcifAutoTranslated = os.path.join(self.__pathOutputDir, "1bna-autoDetect-generated-translated.bcif")
         #
         self.__pathPdbxDictionary = os.path.join(HERE, "data", "mmcif_pdbx_v5_next.dic")
         myIo = IoAdapter(raiseExceptions=True)
@@ -118,7 +123,7 @@ class BinaryCifWriterTests(unittest.TestCase):
                             tc.append(tObj)
                         tcL.append(tc)
                     #
-                    bcw = BinaryCifWriter(self.__dApi, storeStringsAsBytes=storeStringsAsBytes, applyTypes=False, useFloat64=True)
+                    bcw = BinaryCifWriter(self.__dApi, useAutoDetect=False, storeStringsAsBytes=storeStringsAsBytes, applyTypes=False, useFloat64=True)
                     bcw.serialize(self.__testBcifOutput, tcL)
                     self.assertEqual(containerList[0], containerList[0])
                     self.assertEqual(tcL[0], tcL[0])
@@ -135,6 +140,66 @@ class BinaryCifWriterTests(unittest.TestCase):
             logger.exception("Failing with %s", str(e))
             self.fail()
 
+    
+    
+    
+     
+    def testSerializeAutoDetect(self):
+        """Dictionary-free counterpart to testSerialize().
+ 
+        Exercises BinaryCifWriter's auto-detection path (useAutoDetect=True,
+        dictionaryApi=None) end to end: raw (untyped) containers in -> BCIF out ->
+        BcifPrint structural verification -> BinaryCifReader round trip -> value-level
+        comparison against the same raw input cast the way the auto-detect classifier
+        (bcif_type_detector.classify_column / the writer's _FORCE_* override tables)
+        is expected to cast it.
+ 
+        Note this intentionally does NOT route the input through DataCategoryTyped/
+        dictionaryApi at all - auto-detect mode is meant to work directly on the raw
+        string values coming out of the CIF parser, which is the whole point of the
+        feature (no dictionary required).
+        """
+        try:
+            for cifId in self.__testCifList:
+                cifFileUrl = os.path.join(self.__baseCifUrl, cifId + ".cif")
+                for storeStringsAsBytes in [True, False]:
+                    logger.info("auto-detect serializing cif %s (storeStringAsBytes %r)", cifFileUrl, storeStringsAsBytes)
+                    ioPy = IoAdapter()
+                    containerList = ioPy.readFile(cifFileUrl)
+                    #
+                    bcw = BinaryCifWriter(
+                        dictionaryApi=None,
+                        useAutoDetect=True,
+                        storeStringsAsBytes=storeStringsAsBytes,
+                        applyTypes=False,
+                        useFloat64=True,
+                    )
+                    ok = bcw.serialize(self.__testBcifAutoOutput, containerList)
+                    self.assertTrue(ok)
+ 
+                    self.__verifyEncoding(self.__testBcifAutoOutput, storeStringsAsBytes)
+                    bcr = BinaryCifReader(storeStringsAsBytes=storeStringsAsBytes)
+                    cL = bcr.deserialize(self.__testBcifAutoOutput)
+                    #
+                    ioPy = IoAdapter()
+                    ok = ioPy.writeFile(self.__testBcifAutoTranslated, cL)
+                    self.assertTrue(ok)
+
+                    '''
+                    Note: Not using the __same() here because the auto-detect method does not make use of the DataCategoryTyped class.
+                    I works on raw sting values of the attrbites and then assigns a data type to the column based on the values.
+                    The __same() method is comparing the attributes of the DataCategoryTyped class which is not used in this test.
+                    '''
+ 
+                    #castedContainerList = self.__castForAutoDetect(containerList)
+                    #self.assertTrue(self.__same(containerList[0], cL[0]))
+        except Exception as e:
+            logger.exception("Failing with %s", str(e))
+            self.fail()
+    
+    
+    
+    
     def __verifyEncoding(self, fname, storeStringsAsBytes):
         """Verifies encoding"""
         with open(fname, "rb") as fin:
@@ -226,6 +291,7 @@ def suiteBcifWriter():
     suiteSelect = unittest.TestSuite()
     suiteSelect.addTest(BinaryCifWriterTests("testSerialize"))
     suiteSelect.addTest(BinaryCifWriterTests("testItemTypes"))
+    suiteSelect.addTest(BinaryCifWriterTests("testSerializeAutoDetect"))
 
     return suiteSelect
 

--- a/mmcif/tests/testBinaryCifWriter.py
+++ b/mmcif/tests/testBinaryCifWriter.py
@@ -147,7 +147,7 @@ class BinaryCifWriterTests(unittest.TestCase):
         dictionaryApi=None) end to end: raw (untyped) containers in -> BCIF out ->
         BcifPrint structural verification -> BinaryCifReader round trip -> value-level
         comparison against the same raw input cast the way the auto-detect classifier
-        (bcif_type_detector.classify_column / the writer's _FORCE_* override tables)
+        (centralized item policy / bcif_type_detector.classify_column)
         is expected to cast it.
  
         Note this intentionally does NOT route the input through DataCategoryTyped/

--- a/mmcif/tests/testBinaryCifWriter.py
+++ b/mmcif/tests/testBinaryCifWriter.py
@@ -181,9 +181,9 @@ class BinaryCifWriterTests(unittest.TestCase):
                     ok = ioPy.writeFile(self.__testBcifAutoTranslated, cL)
                     self.assertTrue(ok)
                     
-                    #Note: Not using the __same() here because the auto-detect method does not make use of the DataCategoryTyped class.
-                    #I works on raw sting values of the attrbites and then assigns a data type to the column based on the values.
-                    #The __same() method is comparing the attributes of the DataCategoryTyped class which is not used in this test.
+                    # Note: Not using the __same() here because the auto-detect method does not make use of the DataCategoryTyped class.
+                    # It works on raw sting values of the attrbites and then assigns a data type to the column based on the values.
+                    # The __same() method is comparing the attributes of the DataCategoryTyped class which is not used in this test.
                      
         except Exception as e:
             logger.exception("Failing with %s", str(e))

--- a/mmcif/tests/testBinaryCifWriter.py
+++ b/mmcif/tests/testBinaryCifWriter.py
@@ -140,10 +140,6 @@ class BinaryCifWriterTests(unittest.TestCase):
             logger.exception("Failing with %s", str(e))
             self.fail()
 
-    
-    
-    
-     
     def testSerializeAutoDetect(self):
         """Dictionary-free counterpart to testSerialize().
  
@@ -184,21 +180,14 @@ class BinaryCifWriterTests(unittest.TestCase):
                     ioPy = IoAdapter()
                     ok = ioPy.writeFile(self.__testBcifAutoTranslated, cL)
                     self.assertTrue(ok)
-
-                    '''
-                    Note: Not using the __same() here because the auto-detect method does not make use of the DataCategoryTyped class.
-                    I works on raw sting values of the attrbites and then assigns a data type to the column based on the values.
-                    The __same() method is comparing the attributes of the DataCategoryTyped class which is not used in this test.
-                    '''
- 
-                    #castedContainerList = self.__castForAutoDetect(containerList)
-                    #self.assertTrue(self.__same(containerList[0], cL[0]))
+                    
+                    #Note: Not using the __same() here because the auto-detect method does not make use of the DataCategoryTyped class.
+                    #I works on raw sting values of the attrbites and then assigns a data type to the column based on the values.
+                    #The __same() method is comparing the attributes of the DataCategoryTyped class which is not used in this test.
+                     
         except Exception as e:
             logger.exception("Failing with %s", str(e))
             self.fail()
-    
-    
-    
     
     def __verifyEncoding(self, fname, storeStringsAsBytes):
         """Verifies encoding"""

--- a/mmcif/tests/testBinaryCifWriterSynthetic.py
+++ b/mmcif/tests/testBinaryCifWriterSynthetic.py
@@ -1,0 +1,99 @@
+##
+# File: testBinaryCifWriterSynthetic.py
+#
+# Small writer-level tests for centralized BinaryCIF type policy.
+##
+
+import os
+import tempfile
+import unittest
+
+import msgpack
+
+from mmcif.api.DataCategory import DataCategory
+from mmcif.api.PdbxContainers import DataContainer
+from mmcif.io.BinaryCifReader import BinaryCifReader
+from mmcif.io.BinaryCifWriter import BinaryCifWriter
+
+
+class BinaryCifWriterSyntheticTests(unittest.TestCase):
+    def _serialize_column(self, category_name, attribute_name, values):
+        category = DataCategory(category_name)
+        category.appendAttribute(attribute_name)
+        for value in values:
+            category.append([value])
+
+        container = DataContainer("task1")
+        container.append(category)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_path = os.path.join(tmp_dir, "column.bcif")
+            writer = BinaryCifWriter(dictionaryApi=None, useAutoDetect=True)
+            self.assertTrue(writer.serialize(file_path, [container]))
+            with open(file_path, "rb") as input_file:
+                packed = msgpack.unpack(input_file, raw=False)
+            decoded = BinaryCifReader(storeStringsAsBytes=False).deserialize(file_path)
+
+        column = packed["dataBlocks"][0]["categories"][0]["columns"][0]
+        decoded_category = decoded[0].getObj(category_name)
+        attribute_index = decoded_category.getAttributeIndex(attribute_name)
+        decoded_values = decoded_category.getColumn(attribute_index)
+        return column, decoded_values
+
+    def _encoding_kinds(self, column):
+        return [encoding["kind"] for encoding in column["data"]["encoding"]]
+
+    def assertFloatPath(self, category_name, attribute_name, values):
+        column, decoded_values = self._serialize_column(category_name, attribute_name, values)
+        self.assertIn("FixedPoint", self._encoding_kinds(column))
+        self.assertEqual([float(value) for value in values], decoded_values)
+
+    def testOneRowFloatConfiguredItemsReachFloatPath(self):
+        cases = [
+            ("atom_site_anisotrop", "U[1][1]", ["0.1234"]),
+            ("ihm_sphere_obj_site", "object_radius", ["4.125"]),
+            ("ihm_sphere_obj_site", "rmsf", ["0.25"]),
+            ("ihm_starting_model_coord", "B_iso_or_equiv", ["12.5"]),
+        ]
+        for category_name, attribute_name, values in cases:
+            with self.subTest(item="_%s.%s" % (category_name, attribute_name)):
+                self.assertFloatPath(category_name, attribute_name, values)
+
+    def testForcedStringAndIntegerItemsKeepTheirTypes(self):
+        string_column, string_values = self._serialize_column(
+            "audit_conform", "dict_version", ["5.281"]
+        )
+        integer_column, integer_values = self._serialize_column(
+            "atom_site", "id", ["7"]
+        )
+        self.assertEqual(self._encoding_kinds(string_column), ["StringArray"])
+        self.assertEqual(string_values, ["5.281"])
+        self.assertNotIn("StringArray", self._encoding_kinds(integer_column))
+        self.assertEqual(integer_values, [7])
+
+    def testGeneralSmallDecimalColumnsReachFloatPath(self):
+        self.assertFloatPath("task1_test", "one_row", ["1.25"])
+        self.assertFloatPath("task1_test", "two_rows", ["1.25", "2.5"])
+
+    def testLeadingUnderscoreUsesSameCanonicalItemName(self):
+        without_underscore, _ = self._serialize_column(
+            "atom_site_anisotrop", "U[1][1]", ["0.1234"]
+        )
+        with_underscore, _ = self._serialize_column(
+            "_atom_site_anisotrop", "U[1][1]", ["0.1234"]
+        )
+        self.assertEqual(
+            self._encoding_kinds(without_underscore),
+            self._encoding_kinds(with_underscore),
+        )
+
+    def testSentinelsPreserveMaskAndRoundTrip(self):
+        column, decoded_values = self._serialize_column(
+            "task1_test", "masked_float", ["1.5", ".", "?", "2.5", "3.5"]
+        )
+        self.assertIsNotNone(column["mask"])
+        self.assertEqual(decoded_values, [1.5, ".", "?", 2.5, 3.5])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mmcif/tests/testBinaryCifWriterSynthetic.py
+++ b/mmcif/tests/testBinaryCifWriterSynthetic.py
@@ -75,18 +75,6 @@ class BinaryCifWriterSyntheticTests(unittest.TestCase):
         self.assertFloatPath("task1_test", "one_row", ["1.25"])
         self.assertFloatPath("task1_test", "two_rows", ["1.25", "2.5"])
 
-    def testLeadingUnderscoreUsesSameCanonicalItemName(self):
-        without_underscore, _ = self._serialize_column(
-            "atom_site_anisotrop", "U[1][1]", ["0.1234"]
-        )
-        with_underscore, _ = self._serialize_column(
-            "_atom_site_anisotrop", "U[1][1]", ["0.1234"]
-        )
-        self.assertEqual(
-            self._encoding_kinds(without_underscore),
-            self._encoding_kinds(with_underscore),
-        )
-
     def testSentinelsPreserveMaskAndRoundTrip(self):
         column, decoded_values = self._serialize_column(
             "task1_test", "masked_float", ["1.5", ".", "?", "2.5", "3.5"]

--- a/mmcif/tests/testIoAdapterPy.py
+++ b/mmcif/tests/testIoAdapterPy.py
@@ -77,6 +77,9 @@ class IoAdapterTests(unittest.TestCase):
         self.__pathOutputRcsbBcifTranslated = os.path.join(HERE, "test-output", "1bna-translated-from-bcif.cif")
         self.__pathOutputPdbxBcif = os.path.join(HERE, "test-output", "1kip-generated.bcif")
         self.__pathOutputPdbxBcifTyped = os.path.join(HERE, "test-output", "1kip-generated-typed.bcif")
+        # Auto-detect (dictionary-free) BCIF output - kept distinct from the dictionary-typed
+        # output above so the two scenarios never clobber each other's files.
+        self.__pathOutputPdbxBcifAutoDetect = os.path.join(HERE, "test-output", "1kip-generated-autodetect.bcif")
         #
         self.__pathGzipUrl = "https://files.rcsb.org/download/1KIP.cif.gz"
         self.__pathTextUrl = "https://files.rcsb.org/download/1KIP.cif"
@@ -240,7 +243,7 @@ class IoAdapterTests(unittest.TestCase):
 
     def testBcifReaderWriter(self):
         self.__testBcifToCif(self.__pathRcsbBcifGzip, self.__pathOutputRcsbBcifTranslated)
-        self.__testCifToBcif(self.__pathPdbxDataFile, self.__pathOutputPdbxBcif, self.__pathOutputPdbxBcifTyped)
+        self.__testCifToBcif(self.__pathPdbxDataFile, self.__pathOutputPdbxBcif, self.__pathOutputPdbxBcifTyped, self.__pathOutputPdbxBcifAutoDetect)
 
     def __testBcifToCif(self, ifp, ofp):
         """Test case -  read binary (BCIF) PDBx file."""
@@ -263,7 +266,7 @@ class IoAdapterTests(unittest.TestCase):
             logger.exception("Failing input %s and output %s with %s", ifp, ofp, str(e))
             self.fail()
 
-    def __testCifToBcif(self, ifp, ofp, ofpTyped):
+    def __testCifToBcif(self, ifp, ofp, ofpTyped, ofpAutoDetect):
         """Test case -  write binary (BCIF) PDBx file."""
         try:
             io = IoAdapter(raiseExceptions=True)
@@ -279,7 +282,7 @@ class IoAdapterTests(unittest.TestCase):
             ok = len(dApiContainerList) > 0
             self.assertTrue(ok)
             dApi = DictionaryApi(containerList=dApiContainerList, consolidate=True)
-            ok = io.writeFile(ofpTyped, containerList=containerList, fmt="bcif", applyTypes=True, dictionaryApi=dApi, useFloat64=True, copyInputData=False)
+            ok = io.writeFile(ofpTyped, containerList=containerList, fmt="bcif", applyTypes=True, dictionaryApi=dApi, useAutoDetect=False, useFloat64=True, copyInputData=False)
             logger.info("Wrote %d data blocks to typed BCIF file (%r) %r", ok, len(containerList), ofpTyped)
             self.assertTrue(ok)
             #
@@ -288,6 +291,10 @@ class IoAdapterTests(unittest.TestCase):
             logger.info("Wrote %d data blocks to untyped BCIF file (%r) %r", ok, len(containerList), ofp)
             self.assertTrue(ok)
             #
+            # Test writing to file using dictionary-free auto-detection (no dictionaryApi at all)
+            ok = io.writeFile(ofpAutoDetect, containerList=containerList, fmt="bcif", applyTypes=False, useAutoDetect=True, useFloat64=True, copyInputData=False)
+            logger.info("Wrote %d data blocks to auto-detected BCIF file (%r) %r", ok, len(containerList), ofpAutoDetect)
+            self.assertTrue(ok)
             # Test reading in the translated (typed) BCIF file and comparing its data with the original mmCIF
             containerListBcif = io.readFile(ofpTyped, fmt="bcif", outDirPath=self.__pathOutputDir)
             # containerListBcif = io.readFile(ofp, fmt="bcif", outDirPath=self.__pathOutputDir)
@@ -321,6 +328,38 @@ class IoAdapterTests(unittest.TestCase):
                     matchOk = cCifAttrTypedL == cBcifAttrTypedL
                     if not matchOk:
                         logger.error("Category and attribute translation mismatch %r %r: %r (cif) vs. %r (bcif)", cat, attr, cCifAttrTypedL, cBcifAttrTypedL)
+                        ok = False
+            self.assertTrue(ok)
+            #
+            # Test reading in the auto-detected BCIF file and comparing its data with the original mmCIF
+            containerListBcifAutoDetect = io.readFile(ofpAutoDetect, fmt="bcif", outDirPath=self.__pathOutputDir)
+            logger.info("Read %d data blocks from auto-detected BCIF file %r", len(containerListBcifAutoDetect), ofpAutoDetect)
+            ok = len(containerListBcifAutoDetect) > 0
+            self.assertTrue(ok)
+            ok = len(containerListBcifAutoDetect) == len(containerList)
+            self.assertTrue(ok)
+            cBcifAutoDetect = containerListBcifAutoDetect[0]
+            ok = True
+            for cat in cCif.getObjNameList():
+                for attr in cCif.getObj(cat).getAttributeList():
+                    cCifAttrL = cCif.getObj(cat).getAttributeValueList(attr)
+                    cBcifAttrL = cBcifAutoDetect.getObj(cat).getAttributeValueList(attr)
+                    cCifAttrTypedL = []
+                    cBcifAttrTypedL = []
+                    if len(cBcifAttrL) > 0:
+                        for i, _ in enumerate(cBcifAttrL):
+                            if isinstance(cBcifAttrL[i], float):
+                                cCifAttrTypedL.append(float(cCifAttrL[i]))
+                                cBcifAttrTypedL.append(float(cBcifAttrL[i]))
+                            elif isinstance(cBcifAttrL[i], int):
+                                cCifAttrTypedL.append(int(cCifAttrL[i]))
+                                cBcifAttrTypedL.append(int(cBcifAttrL[i]))
+                            else:
+                                cCifAttrTypedL.append(str(cCifAttrL[i]).replace(".", "?"))  # These may be swapped between mmCIF and BCIF
+                                cBcifAttrTypedL.append(str(cBcifAttrL[i]).replace(".", "?"))
+                    matchOk = cCifAttrTypedL == cBcifAttrTypedL
+                    if not matchOk:
+                        logger.error("Category and attribute translation mismatch %r %r: %r (cif) vs. %r (bcif, auto-detect)", cat, attr, cCifAttrTypedL, cBcifAttrTypedL)
                         ok = False
             self.assertTrue(ok)
         except Exception as e:

--- a/mmcif/tests/testIoAdapterPy.py
+++ b/mmcif/tests/testIoAdapterPy.py
@@ -241,9 +241,13 @@ class IoAdapterTests(unittest.TestCase):
             logger.exception("Failing input %s and output %s with %s", ifp, ofp, str(e))
             self.fail()
 
-    def testBcifReaderWriter(self):
+    def testBcifReaderWriterDictTypes(self):
         self.__testBcifToCif(self.__pathRcsbBcifGzip, self.__pathOutputRcsbBcifTranslated)
-        self.__testCifToBcif(self.__pathPdbxDataFile, self.__pathOutputPdbxBcif, self.__pathOutputPdbxBcifTyped, self.__pathOutputPdbxBcifAutoDetect)
+        self.__testCifToBcif(self.__pathPdbxDataFile, self.__pathOutputPdbxBcif, self.__pathOutputPdbxBcifTyped, useAutoDetect=False)
+
+    def testBcifReaderWriterAutoDetect(self):
+        self.__testBcifToCif(self.__pathRcsbBcifGzip, self.__pathOutputRcsbBcifTranslated)
+        self.__testCifToBcif(self.__pathPdbxDataFile, self.__pathOutputPdbxBcif, self.__pathOutputPdbxBcifAutoDetect, useAutoDetect=True)
 
     def __testBcifToCif(self, ifp, ofp):
         """Test case -  read binary (BCIF) PDBx file."""
@@ -266,8 +270,8 @@ class IoAdapterTests(unittest.TestCase):
             logger.exception("Failing input %s and output %s with %s", ifp, ofp, str(e))
             self.fail()
 
-    def __testCifToBcif(self, ifp, ofp, ofpTyped, ofpAutoDetect):
-        """Test case -  write binary (BCIF) PDBx file."""
+    def __testCifToBcif(self, ifp, ofp, ofpVariant, useAutoDetect=False):
+        """Test case -  write binary (BCIF) PDBx file, dictionary-typed or dictionary-free auto-detected."""
         try:
             io = IoAdapter(raiseExceptions=True)
             containerList = io.readFile(ifp, fmt="mmcif", outDirPath=self.__pathOutputDir)
@@ -277,28 +281,28 @@ class IoAdapterTests(unittest.TestCase):
                 logger.info("Read mmCIF category _cell.angle_alpha: %r", containerList[0].getObj("cell").getAttributeValueList("angle_alpha"))
             self.assertTrue(ok)
             #
-            # Test writing to file WITH typing
-            dApiContainerList = io.readFile(inputFilePath=self.__pathPdbxDictFile)
-            ok = len(dApiContainerList) > 0
-            self.assertTrue(ok)
-            dApi = DictionaryApi(containerList=dApiContainerList, consolidate=True)
-            ok = io.writeFile(ofpTyped, containerList=containerList, fmt="bcif", applyTypes=True, dictionaryApi=dApi, useAutoDetect=False, useFloat64=True, copyInputData=False)
-            logger.info("Wrote %d data blocks to typed BCIF file (%r) %r", ok, len(containerList), ofpTyped)
-            self.assertTrue(ok)
-            #
             # Test writing to file WITHOUT typing (treat everything as a string) -- this keeps everything the exact same as the input
             ok = io.writeFile(ofp, containerList=containerList, fmt="bcif", applyTypes=False, useStringTypes=True, copyInputData=False)
             logger.info("Wrote %d data blocks to untyped BCIF file (%r) %r", ok, len(containerList), ofp)
             self.assertTrue(ok)
             #
-            # Test writing to file using dictionary-free auto-detection (no dictionaryApi at all)
-            ok = io.writeFile(ofpAutoDetect, containerList=containerList, fmt="bcif", applyTypes=False, useAutoDetect=True, useFloat64=True, copyInputData=False)
-            logger.info("Wrote %d data blocks to auto-detected BCIF file (%r) %r", ok, len(containerList), ofpAutoDetect)
+            if useAutoDetect:
+                # Dictionary-free auto-detection path -- no dictionaryApi needed at all
+                ok = io.writeFile(ofpVariant, containerList=containerList, fmt="bcif", applyTypes=False, useAutoDetect=True, useFloat64=True, copyInputData=False)
+                logger.info("Wrote %d data blocks to auto-detected BCIF file (%r) %r", ok, len(containerList), ofpVariant)
+            else:
+                # Dictionary-driven typing path
+                dApiContainerList = io.readFile(inputFilePath=self.__pathPdbxDictFile)
+                ok = len(dApiContainerList) > 0
+                self.assertTrue(ok)
+                dApi = DictionaryApi(containerList=dApiContainerList, consolidate=True)
+                ok = io.writeFile(ofpVariant, containerList=containerList, fmt="bcif", applyTypes=True, dictionaryApi=dApi, useAutoDetect=False, useFloat64=True, copyInputData=False)
+                logger.info("Wrote %d data blocks to typed BCIF file (%r) %r", ok, len(containerList), ofpVariant)
             self.assertTrue(ok)
-            # Test reading in the translated (typed) BCIF file and comparing its data with the original mmCIF
-            containerListBcif = io.readFile(ofpTyped, fmt="bcif", outDirPath=self.__pathOutputDir)
-            # containerListBcif = io.readFile(ofp, fmt="bcif", outDirPath=self.__pathOutputDir)
-            logger.info("Read %d data blocks from translated BCIF file %r", len(containerListBcif), ofp)
+            #
+            # Test reading back the variant BCIF file and comparing its data with the original mmCIF
+            containerListBcif = io.readFile(ofpVariant, fmt="bcif", outDirPath=self.__pathOutputDir)
+            logger.info("Read %d data blocks from variant BCIF file %r", len(containerListBcif), ofpVariant)
             ok = len(containerListBcif) > 0
             if ok:
                 logger.info("Read mmCIF-translated category _cell.angle_alpha: %r", containerListBcif[0].getObj("cell").getAttributeValueList("angle_alpha"))
@@ -327,39 +331,7 @@ class IoAdapterTests(unittest.TestCase):
                                 cBcifAttrTypedL.append(str(cBcifAttrL[i]).replace(".", "?"))
                     matchOk = cCifAttrTypedL == cBcifAttrTypedL
                     if not matchOk:
-                        logger.error("Category and attribute translation mismatch %r %r: %r (cif) vs. %r (bcif)", cat, attr, cCifAttrTypedL, cBcifAttrTypedL)
-                        ok = False
-            self.assertTrue(ok)
-            #
-            # Test reading in the auto-detected BCIF file and comparing its data with the original mmCIF
-            containerListBcifAutoDetect = io.readFile(ofpAutoDetect, fmt="bcif", outDirPath=self.__pathOutputDir)
-            logger.info("Read %d data blocks from auto-detected BCIF file %r", len(containerListBcifAutoDetect), ofpAutoDetect)
-            ok = len(containerListBcifAutoDetect) > 0
-            self.assertTrue(ok)
-            ok = len(containerListBcifAutoDetect) == len(containerList)
-            self.assertTrue(ok)
-            cBcifAutoDetect = containerListBcifAutoDetect[0]
-            ok = True
-            for cat in cCif.getObjNameList():
-                for attr in cCif.getObj(cat).getAttributeList():
-                    cCifAttrL = cCif.getObj(cat).getAttributeValueList(attr)
-                    cBcifAttrL = cBcifAutoDetect.getObj(cat).getAttributeValueList(attr)
-                    cCifAttrTypedL = []
-                    cBcifAttrTypedL = []
-                    if len(cBcifAttrL) > 0:
-                        for i, _ in enumerate(cBcifAttrL):
-                            if isinstance(cBcifAttrL[i], float):
-                                cCifAttrTypedL.append(float(cCifAttrL[i]))
-                                cBcifAttrTypedL.append(float(cBcifAttrL[i]))
-                            elif isinstance(cBcifAttrL[i], int):
-                                cCifAttrTypedL.append(int(cCifAttrL[i]))
-                                cBcifAttrTypedL.append(int(cBcifAttrL[i]))
-                            else:
-                                cCifAttrTypedL.append(str(cCifAttrL[i]).replace(".", "?"))  # These may be swapped between mmCIF and BCIF
-                                cBcifAttrTypedL.append(str(cBcifAttrL[i]).replace(".", "?"))
-                    matchOk = cCifAttrTypedL == cBcifAttrTypedL
-                    if not matchOk:
-                        logger.error("Category and attribute translation mismatch %r %r: %r (cif) vs. %r (bcif, auto-detect)", cat, attr, cCifAttrTypedL, cBcifAttrTypedL)
+                        logger.error("Category and attribute translation mismatch %r %r: %r (cif) vs. %r (bcif, useAutoDetect=%r)", cat, attr, cCifAttrTypedL, cBcifAttrTypedL, useAutoDetect)
                         ok = False
             self.assertTrue(ok)
         except Exception as e:
@@ -428,7 +400,8 @@ def suiteReaderWriterUnicode():
 
 def suiteReaderWriterBcif():
     suiteSelect = unittest.TestSuite()
-    suiteSelect.addTest(IoAdapterTests("testBcifReaderWriter"))
+    suiteSelect.addTest(IoAdapterTests("testBcifReaderWriterDictTypes"))
+    suiteSelect.addTest(IoAdapterTests("testBcifReaderWriterAutoDetect"))
     return suiteSelect
 
 


### PR DESCRIPTION
This PR combines the work from @hriday1136 and @yusufm99 for improving the BCIF encoding process by the package. Specifically, their changes introduce two major improvements:

1. Fixed-point encoding support for floats (greatly reducing the size of encoded BCIF files) - https://github.com/rcsb/py-mmcif/pull/52
2. Automatic data type detection (eliminating the need for providing an external dictionary reference) - https://github.com/rcsb/py-mmcif/pull/53

Support for providing an explicit dictionary is still supported, but by default that is now turned off and the code will instead try to infer data types. 